### PR TITLE
Some fixes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ output/
 notes/
 stuff/
 *.un~
+hydra_log/
+
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/configs/workload/bert_test.yaml
+++ b/configs/workload/bert_test.yaml
@@ -11,14 +11,14 @@ workflow:
 dataset: 
  data_folder: ./data/bert/
  format: tfrecord
- num_files_train: 500
- num_samples_per_file: 313532
+ num_files_train: 10
+ num_samples_per_file: 313
  record-length: 2500
- batch_size: 48
+ batch_size: 7
 
 train:
  computation_time: 0.968
- total_training_steps: 5000
+ total_training_steps: 200
  
 data_reader:
  data_loader: tensorflow
@@ -27,5 +27,5 @@ data_reader:
  transfer_size: 262144
 
 checkpoint:
- steps_between_checkpoints: 1250
- model_size: 4034713312
+ steps_between_checkpoints: 100
+ model_size: 40347133

--- a/configs/workload/unet3d.yaml
+++ b/configs/workload/unet3d.yaml
@@ -16,7 +16,7 @@ dataset:
   batch_size: 4
   batch_size_eval: 1
   file_access: multi
-  record_length: 1145359
+  record_length: 147000000
   keep_files: True
   
 data_reader: 

--- a/configs/workload/unet3d_test.yaml
+++ b/configs/workload/unet3d_test.yaml
@@ -10,8 +10,8 @@ workflow:
 dataset: 
   data_folder: ./data/unet3d/
   format: npz
-  num_files_train: 3620
-  num_files_eval: 42
+  num_files_train: 300
+  num_files_eval: 20
   num_samples_per_file: 1
   batch_size: 4
   batch_size_eval: 1
@@ -23,9 +23,10 @@ data_reader:
   data_loader: pytorch
 
 train:
-  epochs: 10
-  computation_time: 4.59
+  epochs: 3
+  computation_time: 0.59
 
 evaluation: 
-  eval_time: 11.572
-  epochs_between_evals: 2
+  eval_time: 1.572
+  eval_after_epoch: 1
+  epochs_between_evals: 1

--- a/src/dlio_postprocessor.py
+++ b/src/dlio_postprocessor.py
@@ -487,7 +487,6 @@ class DLIOPostProcessor:
 
             format_print(outfile, overall_desc, indent=1)
             if (self.iotrace is not None):
-                print(self.iotrace)
                 write_out_stats_table(outfile, self.overall_stats, indent=1)
 
             outfile.write("\nDetailed Report\n\n")

--- a/src/framework/tf_framework.py
+++ b/src/framework/tf_framework.py
@@ -35,8 +35,9 @@ class TFFramework(Framework):
     def __init__(self, profiling):
         super().__init__()
         self.profiling = profiling
+        # TODO: Temporary fix, need to separate the iostat profiler (needed for report gen) and the others
         if profiling:
-            self.tensorboard = ProfilerFactory.get_profiler(Profiler.TENSORBOARD)
+            self.tensorboard = ProfilerFactory.get_profiler(Profiler.NONE)
         self.reader_handler = None
 
     def init_reader(self, format_type, data_loader=None):

--- a/src/profiler/iostat_profiler.py
+++ b/src/profiler/iostat_profiler.py
@@ -32,6 +32,7 @@ class IostatProfiler(IOProfiler):
     def __init__(self):
         super().__init__()
         self.my_rank = self._args.my_rank
+        self.devices = self._args.io_devices_to_trace
         self.logfile = os.path.join(self._args.output_folder, 'iostat.json')
         """ Virtually private constructor. """
         if IostatProfiler.__instance is not None:
@@ -43,8 +44,9 @@ class IostatProfiler(IOProfiler):
         if self.my_rank == 0:
             # Open the logfile for writing
             self.logfile = open(self.logfile, 'w')
-            #TODO: Get the relevant disks (from user input?)
-            cmd = ["iostat", "-mdxtcy", "-o", "JSON", "sda", "sdb", "1"]
+            cmd = ["iostat", "-mdxtcy", "-o", "JSON"]
+            cmd.extend(self.devices)
+            cmd.append("1")
             self.process = sp.Popen(cmd, stdout=self.logfile, stderr=self.logfile)
 
     def stop(self):

--- a/src/profiler/no_profiler.py
+++ b/src/profiler/no_profiler.py
@@ -18,8 +18,8 @@ from src.profiler.io_profiler import IOProfiler
 
 
 class NoProfiler(IOProfiler):
-    def __init__(self, logdir):
-        super().__init__(logdir)
+    def __init__(self):
+        super().__init__()
 
     def start(self):
         pass

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -105,7 +105,7 @@ def LoadConfig(args, config):
         args.logdir = config['logdir']
     if 'reporting' in config:
         args.io_devices_to_trace = config['reporting']['devices']
-        if not isinstance(args.io_devices_to_trace, list):
+        if isinstance(args.io_devices_to_trace, str):
             args.io_devices_to_trace = [args.io_devices_to_trace]
     # dataset related settings
     if 'dataset' in config:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -47,8 +47,12 @@ class ConfigArguments:
     log_file: str  = "dlio.log"
     file_prefix: str = "img"
     keep_files: bool = True
-    do_profiling: bool = False
-    profiler: Profiler = Profiler.NONE
+    # TODO: Separate the general profiler iostat, beeded for benchmark report generation
+    # and framework specific profiler/ other profiler (i.e. darshan)
+    do_profiling: bool = True
+    profiler: Profiler = Profiler.IOSTAT
+    # Will trace all io devices by default
+    io_devices_to_trace = []
     seed: int = 123
     do_checkpoint: bool = False
     checkpoint_after_epoch: int = 1 
@@ -99,6 +103,10 @@ def LoadConfig(args, config):
         args.framework = FrameworkType(config['framework'])
     if 'logdir' in config:
         args.logdir = config['logdir']
+    if 'reporting' in config:
+        args.io_devices_to_trace = config['reporting']['devices']
+        if not isinstance(args.io_devices_to_trace, list):
+            args.io_devices_to_trace = [args.io_devices_to_trace]
     # dataset related settings
     if 'dataset' in config:
         if 'record_length' in config['dataset']:

--- a/src/utils/utility.py
+++ b/src/utils/utility.py
@@ -38,7 +38,7 @@ def progress(count, total, status=''):
         os.sys.stdout.flush()
 
 def utcnow(format=LOG_TS_FORMAT):
-    return datetime.utcnow().strftime(format)
+    return datetime.now().strftime(format)
 
 def str2bool(v):
     if isinstance(v, bool):


### PR DESCRIPTION
Touch up README 
- fix typos, add details for report generation, tell user to flush caches between datagen and run.

Change default UNET3D and BERT params 
- I think we shouldn't encourage running datagen and run right after since the report generated will be wrong due to not flushing the caches. 
- Some of the parameter values were wrong e.g. file size for UNET3D

Fix iostat running 
- Add parameter to specify which io devices to trace 
- Change logging time to local time, to match with iostat (though this might not work on all machines depending on the time config)
- Since we're trying to remain general, you may not want to run iostat all the time? I dont know.

Add test configs for bert and unet that finish quickly to test the end-to-end process.


ISSUES:
- The BERT workload should currenty be run with only 1 process (mpirun -np 1) and the "num gpus" should be used as input to the number of computation threads and to scale the batch size (6 * num_gpus). Running bert with more than one process doesn't work currently and does not properly scale like the real workload (which uses a single process). We should specify this in the README, and add a parameter, though it will be redundant for UNET3D which simply uses the mpi num-procs 