### PR TITLE
Adding PR unit tests for testing different data format and fixing issues for reading png and jpeg with pytorch data folder. 

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,6 +21,17 @@ jobs:
         sudo apt-get install mpich
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+	pip install pytest-mpi
+    - name: pytest-seq
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        python3 -m pytest -v
+    - name: pytest-mpi
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        mpirun -np 2 python3 -m pytest
     - name: test-tf-loader-tfrecord
       run: |
         touch __init__.py

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
         sudo apt-get install mpich
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-	pip install pytest-mpi
+        pip install pytest-mpi
     - name: pytest-seq
       run: |
         touch __init__.py

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 -m pytest
+        mpirun -np 2 python3 -m pytest  --with-mpi
     - name: test-tf-loader-tfrecord
       run: |
         touch __init__.py

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,7 +21,7 @@ jobs:
         sudo apt-get install mpich
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest-mpi
+        pip install pytest pytest-mpi pytest-subtests 
     - name: pytest-seq
       run: |
         touch __init__.py

--- a/src/data_generator/tf_generator.py
+++ b/src/data_generator/tf_generator.py
@@ -47,7 +47,7 @@ class TFRecordGenerator(DataGenerator):
                 # Open a TFRecordWriter for the output-file.
                 with tf.io.TFRecordWriter(out_path_spec) as writer:
                     for i in range(0, self.num_samples):
-                        img_bytes = record.tostring()
+                        img_bytes = record.tobytes()
                         data = {
                             'image': tf.train.Feature(bytes_list=tf.train.BytesList(value=[img_bytes])),
                             'label': tf.train.Feature(int64_list=tf.train.Int64List(value=[record_label]))

--- a/src/dlio_benchmark.py
+++ b/src/dlio_benchmark.py
@@ -232,6 +232,7 @@ class DLIOBenchmark(object):
 
             self.stats.batch_processed(epoch, overall_step, block, t0)
 
+
             if self.do_checkpoint and (self.steps_between_checkpoints>=0) and overall_step == self.next_checkpoint_step:
                 self.stats.end_block(epoch, block, block_step)
                 self.stats.start_ckpt(epoch, block, overall_step)
@@ -242,14 +243,16 @@ class DLIOBenchmark(object):
                 # Reset the number of steps after every checkpoint to mark the start of a new block
                 block_step = 1
                 self.next_checkpoint_step += self.steps_between_checkpoints
+            else:
+                block_step += 1
 
             if overall_step >= max_steps or overall_step == self.total_training_steps:
                 self.framework.barrier()
                 logging.info(f"{utcnow()} Maximum number of steps reached")
-                self.stats.end_block(epoch, block, block_step)
+                if (block_step!=1 and self.do_checkpoint) or (not self.do_checkpoint):
+                    self.stats.end_block(epoch, block, block_step-1)
                 break
-
-            block_step += 1
+                
             overall_step += 1
 
             t0 = time()
@@ -283,9 +286,9 @@ class DLIOBenchmark(object):
             # Keep track of the next epoch at which we will evaluate
             next_eval_epoch = self.eval_after_epoch
             self.next_checkpoint_epoch = self.checkpoint_after_epoch
-            self.next_checkpoint_step = self.steps_between_checkpoints
 
             for epoch in range(1, self.epochs + 1):
+                self.next_checkpoint_step = self.steps_between_checkpoints                
                 self.stats.start_epoch(epoch)
 
                 # Initialize the dataset

--- a/src/dlio_benchmark.py
+++ b/src/dlio_benchmark.py
@@ -89,7 +89,7 @@ class DLIOBenchmark(object):
         if self.my_rank == 0:
             if os.path.isfile(self.logfile):
                 os.remove(self.logfile)
-
+        self.framework.barrier()
         # Configure the logging library
         log_level = logging.DEBUG if self.args.debug else logging.INFO
         logging.basicConfig(

--- a/src/reader/torch_data_loader_reader.py
+++ b/src/reader/torch_data_loader_reader.py
@@ -27,14 +27,15 @@ from torch.utils.data.distributed import DistributedSampler
 from src.common.enumerations import Shuffle, FormatType
 from src.reader.reader_handler import FormatReader
 
-from torchvision.io import read_image, decode_png, decode_jpeg, read_file
-
+from PIL import Image
+import torchvision.transforms as transforms
+totensor=transforms.ToTensor()
 ### reading file of different formats. 
 def read_jpeg(filename):
-    return read_image(filename)
+    return totensor(Image.open(filename))
 
 def read_png(filename):
-    return read_image(filename)
+    return totensor(Image.open(filename))
 
 def read_npz(filename):
     return np.load(filename)
@@ -42,7 +43,12 @@ def read_npz(filename):
 def read_hdf5(f):
     file_h5 = h5py.File(file, 'r')
     d = file_h5['x']
-    return d
+    return totensor(d)
+
+def read_file(f):
+    with open(f, mode='rb') as file: # b is important -> binary
+        fileContent = file.read()
+    return fileContent
 
 filereader={
     FormatType.JPEG: read_jpeg, 

--- a/src/utils/statscounter.py
+++ b/src/utils/statscounter.py
@@ -111,7 +111,7 @@ class StatsCounter(object):
     def start_ckpt(self, epoch, block, steps_taken):
         if self.my_rank == 0:
             ts = utcnow()
-            logging.info(f"{ts} Starting checkpoint {block} after total step {steps_taken}")
+            logging.info(f"{ts} Starting checkpoint {block} after total step {steps_taken} for epoch {epoch}")
             self.per_epoch_stats[epoch][f'ckpt{block}'] = {
                 'start': ts
             }
@@ -121,7 +121,7 @@ class StatsCounter(object):
             ts = utcnow()
             duration = pd.to_datetime(ts) - pd.to_datetime(self.per_epoch_stats[epoch][f'ckpt{block}']['start'])
             duration = '{:.2f}'.format(duration.total_seconds())
-            logging.info(f"{ts} Ending checkpoint {block}")
+            logging.info(f"{ts} Ending checkpoint {block} for epoch {epoch}")
 
             self.per_epoch_stats[epoch][f'ckpt{block}']['end'] = ts
             self.per_epoch_stats[epoch][f'ckpt{block}']['duration'] = duration

--- a/src/utils/statscounter.py
+++ b/src/utils/statscounter.py
@@ -83,7 +83,6 @@ class StatsCounter(object):
             duration = pd.to_datetime(ts)- pd.to_datetime(self.per_epoch_stats[epoch]['eval']['start'])
             duration = '{:.2f}'.format(duration.total_seconds())
             logging.info(f"{ts} Ending eval - {self.steps_eval} steps completed in {duration} s")
-
             self.per_epoch_stats[epoch]['eval']['end'] = ts
             self.per_epoch_stats[epoch]['eval']['duration'] = duration        
 
@@ -106,7 +105,6 @@ class StatsCounter(object):
             duration = pd.to_datetime(ts) - pd.to_datetime(self.per_epoch_stats[epoch][f'block{block}']['start'])
             duration = '{:.2f}'.format(duration.total_seconds())
             logging.info(f"{ts} Ending block {block} - {steps_taken} steps completed in {duration} s")
-
             self.per_epoch_stats[epoch][f'block{block}']['end'] = ts
             self.per_epoch_stats[epoch][f'block{block}']['duration'] = duration
 

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -7,44 +7,132 @@ from omegaconf import DictConfig, OmegaConf
 import hydra
 import unittest
 import yaml
+import shutil
 
-from omegaconf import OmegaConf
+import pytest
 
 import os
 
 from src.dlio_benchmark import DLIOBenchmark
 import glob
 class TestDLIOBenchmark(unittest.TestCase):
-    def test_step0_gen_data(self) -> None:
-        with initialize(version_base=None, config_path="../configs"):
-            cfg = compose(config_name='config', overrides=['++workload.workflow.train=False', '++workload.workflow.generate_data=True'])
-            
-            benchmark = DLIOBenchmark(cfg['workload'])
-            benchmark.initialize()
-            benchmark.run()
-            benchmark.finalize()
-            if benchmark.args.num_subfolders_train<=1:
-                assert(len(glob.glob(cfg.workload.dataset.data_folder + "train/*.npz"))==cfg.workload.dataset.num_files_train)
-                assert(len(glob.glob(cfg.workload.dataset.data_folder + "valid/*.npz"))==cfg.workload.dataset.num_files_eval)
-            else:
-                assert(len(glob.glob(cfg.workload.dataset.data_folder + "train/*/*.npz"))==cfg.workload.dataset.num_files_train)
-                assert(len(glob.glob(cfg.workload.dataset.data_folder + "valid/*/*.npz"))==cfg.workload.dataset.num_files_eval)
-                
-        return 0
-    def test_step1_train(self) -> None:
+    def clean(self) -> None:
+        shutil.rmtree("./checkpoints", ignore_errors=True)
+        shutil.rmtree("./data/", ignore_errors=True)
+        shutil.rmtree("./output", ignore_errors=True)
+    def run_benchmark(self, cfg):
+        shutil.rmtree("./output", ignore_errors=True)
+        benchmark = DLIOBenchmark(cfg['workload'])
+        benchmark.initialize()
+        benchmark.run()
+        benchmark.finalize()
+        return benchmark
+    def test0_gen_data1_formats(self) -> None:
+        for fmt in "tfrecord", "jpeg", "png", "npz":
+            with self.subTest(f"Testing data generator for format: {fmt}", fmt=fmt):
+                self.clean()
+                with initialize(version_base=None, config_path="../configs"):
+                    cfg = compose(config_name='config', overrides=['++workload.workflow.train=False', \
+                                                                   '++workload.workflow.generate_data=True',
+                                                                   f"++workload.dataset.format={fmt}"])
+                    benchmark=self.run_benchmark(cfg)
+                    if benchmark.args.num_subfolders_train<=1:
+                        self.assertEqual(len(glob.glob(cfg.workload.dataset.data_folder + f"train/*.{fmt}")), cfg.workload.dataset.num_files_train)
+                        self.assertEqual(len(glob.glob(cfg.workload.dataset.data_folder + f"valid/*.{fmt}")), cfg.workload.dataset.num_files_eval)
+                    else:
+                        self.assertEqual(len(glob.glob(cfg.workload.dataset.data_folder + f"train/*/*.{fmt}")), cfg.workload.dataset.num_files_train)
+                        self.assertEqual(len(glob.glob(cfg.workload.dataset.data_folder + f"valid/*/*.{fmt}")), cfg.workload.dataset.num_files_eval)
+        
+    def test1_train(self) -> None:
         with initialize(version_base=None, config_path="../configs"):
             cfg = compose(config_name='config', overrides=['++workload.workflow.train=True', '++workload.workflow.generate_data=False', 'workload.train.computation_time=0.01', 'workload.evaluation.eval_time=0.005', 'workload.train.epochs=1'])
-            benchmark = DLIOBenchmark(cfg['workload'])
-            benchmark.initialize()
-            benchmark.run()
-            benchmark.finalize()
+            benchmark=self.run_benchmark(cfg)            
+
             os.makedirs(benchmark.output_folder+"/.hydra/", exist_ok=True)
             yl: str = OmegaConf.to_yaml(cfg)
             with open(benchmark.output_folder+"./.hydra/config.yaml", "w") as f:
                 OmegaConf.save(cfg, f)
             with open(benchmark.output_folder+"./.hydra/overrides.yaml", "w") as f:
                 f.write('[]')
-            assert(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json"))==benchmark.comm_size)
-
+            self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)
+    def test2_checkpoint1_epoch(self) -> None:
+        with initialize(version_base=None, config_path="../configs"):
+            cfg = compose(config_name='config',
+                          overrides=['++workload.workflow.train=True',\
+                                     '++workload.workflow.generate_data=False', \
+                                     '++workload.train.computation_time=0.01', \
+                                     '++workload.evaluation.eval_time=0.005', \
+                                     '++workload.train.epochs=8', '++workload.workflow.checkpoint=True', \
+                                     '++workload.checkpoint.epochs_between_checkpoints=2'])
+            shutil.rmtree("./checkpoints", ignore_errors=True)                                    
+            benchmark=self.run_benchmark(cfg)            
+            self.assertEqual(len(glob.glob("./checkpoints/*.bin")), 4)
+    def test2_checkpoint2_step(self) -> None:
+        with initialize(version_base=None, config_path="../configs"):
+            cfg = compose(config_name='config',
+                          overrides=['++workload.workflow.train=True',\
+                                     '++workload.workflow.generate_data=False', \
+                                     '++workload.train.computation_time=0.01', \
+                                     '++workload.evaluation.eval_time=0.005', \
+                                     '++workload.train.epochs=8', '++workload.workflow.checkpoint=True', \
+                                     '++workload.checkpoint.steps_between_checkpoints=2'])
+            benchmark = DLIOBenchmark(cfg['workload'])
+            dataset = cfg['workload']['dataset']
+            nstep = dataset.num_files_train * dataset.num_samples_per_file // dataset.batch_size//benchmark.comm_size
+            ncheckpoints=nstep//2*8
+            shutil.rmtree("./checkpoints", ignore_errors=True)                        
+            benchmark=self.run_benchmark(cfg)                        
+            self.assertEqual(len(glob.glob("./checkpoints/*.bin")), ncheckpoints)
+    def test3_eval(self) -> None:
+        with initialize(version_base=None, config_path="../configs"):
+            cfg = compose(config_name='config',
+                          overrides=['++workload.workflow.train=True',\
+                                     '++workload.workflow.generate_data=False', \
+                                     'workload.train.computation_time=0.01', \
+                                     'workload.evaluation.eval_time=0.005', \
+                                     '++workload.train.epochs=4', '++workload.workflow.evaluation=True'])
+            benchmark=self.run_benchmark(cfg)
+            self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)            
+    def test2_tf_loader(self) -> None:
+        with initialize(version_base=None, config_path="../configs"):
+            cfg = compose(config_name='config',
+                          overrides=['++workload.data_reader.data_loader=tensorflow',\
+                                     '++workload.framework=tensorflow', \
+                                     '++workload.workflow.generate_data=False', \
+                                     'workload.train.computation_time=0.01', \
+                                     'workload.evaluation.eval_time=0.005', \
+                                     '++workload.train.epochs=4', '++workload.workflow.evaluation=True'])
+            benchmark = self.run_benchmark(cfg)                                                
+            self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)            
+    def test2_torch_loader(self) -> None:
+        with initialize(version_base=None, config_path="../configs"):
+            cfg = compose(config_name='config',
+                          overrides=['++workload.data_reader.data_loader=pytorch',\
+                                     '++workload.framework=pytorch', \
+                                     '++workload.workflow.generate_data=False', \
+                                     'workload.train.computation_time=0.01', \
+                                     'workload.evaluation.eval_time=0.005', \
+                                     '++workload.train.epochs=4', '++workload.workflow.evaluation=True'])
+            benchmark = self.run_benchmark(cfg)
+            self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)            
+    def test_full_formats(self) -> None:
+        for fmt in "tfrecord", "jpeg", "png", "npz":
+            with self.subTest(f"Testing full benchmark for format: {fmt}", fmt=fmt):
+                for framework in "tensorflow", "pytorch":
+                    if fmt=="tfrecord" and framework=="pytorch":
+                        pass
+                    self.clean()
+                    with initialize(version_base=None, config_path="../configs"):
+                        cfg = compose(config_name='config', overrides=['++workload.workflow.train=True', \
+                                                                       '++workload.workflow.generate_data=True',\
+                                                                       f"++workload.framework={framework}", \
+                                                                       f"++workload.data_reader.data_loader={framework}", \
+                                                                       f"++workload.dataset.format={fmt}", 
+                                                                       'workload.train.computation_time=0.01', \
+                                                                       'workload.evaluation.eval_time=0.005', \
+                                                                       '++workload.train.epochs=1', \
+                                                                       '++workload.dataset.num_files_train=4'])
+                        benchmark=self.run_benchmark(cfg)
+                        self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)
 if __name__ == '__main__':
     unittest.main()

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -8,7 +8,8 @@ import hydra
 import unittest
 import yaml
 import shutil
-
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
 import pytest
 
 import os
@@ -17,11 +18,17 @@ from src.dlio_benchmark import DLIOBenchmark
 import glob
 class TestDLIOBenchmark(unittest.TestCase):
     def clean(self) -> None:
-        shutil.rmtree("./checkpoints", ignore_errors=True)
-        shutil.rmtree("./data/", ignore_errors=True)
-        shutil.rmtree("./output", ignore_errors=True)
+        comm.Barrier()
+        if (comm.rank==0):
+            shutil.rmtree("./checkpoints", ignore_errors=True)
+            shutil.rmtree("./data/", ignore_errors=True)
+            shutil.rmtree("./output", ignore_errors=True)
+        comm.Barrier()
     def run_benchmark(self, cfg):
-        shutil.rmtree("./output", ignore_errors=True)
+        comm.Barrier()
+        if (comm.rank==0):
+            shutil.rmtree("./output", ignore_errors=True)
+        comm.Barrier()            
         benchmark = DLIOBenchmark(cfg['workload'])
         benchmark.initialize()
         benchmark.run()
@@ -47,13 +54,13 @@ class TestDLIOBenchmark(unittest.TestCase):
         with initialize(version_base=None, config_path="../configs"):
             cfg = compose(config_name='config', overrides=['++workload.workflow.train=True', '++workload.workflow.generate_data=False', 'workload.train.computation_time=0.01', 'workload.evaluation.eval_time=0.005', 'workload.train.epochs=1'])
             benchmark=self.run_benchmark(cfg)            
-
-            os.makedirs(benchmark.output_folder+"/.hydra/", exist_ok=True)
-            yl: str = OmegaConf.to_yaml(cfg)
-            with open(benchmark.output_folder+"./.hydra/config.yaml", "w") as f:
-                OmegaConf.save(cfg, f)
-            with open(benchmark.output_folder+"./.hydra/overrides.yaml", "w") as f:
-                f.write('[]')
+            if (comm.rank==0):
+                os.makedirs(benchmark.output_folder+"/.hydra/", exist_ok=True)
+                yl: str = OmegaConf.to_yaml(cfg)
+                with open(benchmark.output_folder+"./.hydra/config.yaml", "w") as f:
+                    OmegaConf.save(cfg, f)
+                with open(benchmark.output_folder+"./.hydra/overrides.yaml", "w") as f:
+                    f.write('[]')
             self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)
     def test2_checkpoint1_epoch(self) -> None:
         with initialize(version_base=None, config_path="../configs"):
@@ -64,7 +71,10 @@ class TestDLIOBenchmark(unittest.TestCase):
                                      '++workload.evaluation.eval_time=0.005', \
                                      '++workload.train.epochs=8', '++workload.workflow.checkpoint=True', \
                                      '++workload.checkpoint.epochs_between_checkpoints=2'])
-            shutil.rmtree("./checkpoints", ignore_errors=True)                                    
+            comm.Barrier()
+            if comm.rank==0:
+                shutil.rmtree("./checkpoints", ignore_errors=True)
+            comm.Barrier()
             benchmark=self.run_benchmark(cfg)            
             self.assertEqual(len(glob.glob("./checkpoints/*.bin")), 4)
     def test2_checkpoint2_step(self) -> None:
@@ -76,12 +86,14 @@ class TestDLIOBenchmark(unittest.TestCase):
                                      '++workload.evaluation.eval_time=0.005', \
                                      '++workload.train.epochs=8', '++workload.workflow.checkpoint=True', \
                                      '++workload.checkpoint.steps_between_checkpoints=2'])
-            benchmark = DLIOBenchmark(cfg['workload'])
+            comm.Barrier()
+            if comm.rank==0:
+                shutil.rmtree("./checkpoints", ignore_errors=True)
+            comm.Barrier()
+            benchmark=self.run_benchmark(cfg)                        
             dataset = cfg['workload']['dataset']
             nstep = dataset.num_files_train * dataset.num_samples_per_file // dataset.batch_size//benchmark.comm_size
             ncheckpoints=nstep//2*8
-            shutil.rmtree("./checkpoints", ignore_errors=True)                        
-            benchmark=self.run_benchmark(cfg)                        
             self.assertEqual(len(glob.glob("./checkpoints/*.bin")), ncheckpoints)
     def test3_eval(self) -> None:
         with initialize(version_base=None, config_path="../configs"):
@@ -102,6 +114,10 @@ class TestDLIOBenchmark(unittest.TestCase):
                                      'workload.train.computation_time=0.01', \
                                      'workload.evaluation.eval_time=0.005', \
                                      '++workload.train.epochs=4', '++workload.workflow.evaluation=True'])
+            comm.Barrier()
+            if comm.rank==0:
+                shutil.rmtree("./output", ignore_errors=True)
+            comm.Barrier()
             benchmark = self.run_benchmark(cfg)                                                
             self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)            
     def test2_torch_loader(self) -> None:


### PR DESCRIPTION
I added the following tests in tests/dlio_benchmark_test.py

* testing the data generation for different formats
* testing full benchmarks for different formats
* testing checkpointing (for both epochs_between_checkpoints and steps_between_checkpoints)

Two pytest tests are included in the GitHub action. 

I also fixed the issues for reading png and jpeg files with torch data loader. 
