### PR TITLE
Adding Storage interface for supporting multiple storage backends

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -27,12 +27,21 @@ jobs:
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
         RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_gen_data
-
+    - name: test_custom_storage_root_gen_data
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_storage_root_gen_data
     - name: test_train
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
         RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_train
+    - name: test_custom_storage_root_train
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_custom_storage_root_train
     - name: test_checkpoint_epoch
       run: |
         touch __init__.py

--- a/configs/workload/bert.yaml
+++ b/configs/workload/bert.yaml
@@ -9,7 +9,7 @@ workflow:
  checkpoint: True
  
 dataset: 
- data_folder: ./data/bert/
+ data_folder: data/bert
  format: tfrecord
  num_files_train: 500
  num_samples_per_file: 313532

--- a/configs/workload/cosmoflow.yaml
+++ b/configs/workload/cosmoflow.yaml
@@ -7,7 +7,7 @@ workflow:
  train: True
 
 dataset:
- data_folder: ./data/cosmoflow
+ data_folder: data/cosmoflow
  num_files_train: 1024
  num_samples_per_file: 512
  record_length: 131072

--- a/configs/workload/default.yaml
+++ b/configs/workload/default.yaml
@@ -9,7 +9,7 @@ workflow:
   profiling: False
 
 dataset: 
-  data_folder: ./data/default/
+  data_folder: data/default
   format: npz
   num_files_train: 64
   num_files_eval: 8

--- a/configs/workload/unet3d.yaml
+++ b/configs/workload/unet3d.yaml
@@ -9,7 +9,7 @@ workflow:
   checkpoint: True
 
 dataset: 
-  data_folder: ./data/unet3d/
+  data_folder: data/unet3d
   format: npz
   num_files_train: 3620
   num_files_eval: 42

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -16,7 +16,7 @@ The characteristics of a workload is specified through a YAML file. This file wi
     evaluation: True
 
   dataset: 
-    data_folder: ./data/unet3d/
+    data_folder: data/unet3d
     format: npz
     num_files_train: 3620
     num_files_eval: 42

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -24,7 +24,7 @@ UNET3D: 3D Medical Image Segmentation
         evaluation: True
 
     dataset: 
-        data_folder: ./data/unet3d/
+        data_folder: data/unet3d
         format: npz
         num_files_train: 3620
         num_files_eval: 42

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ tensorboard==2.11.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
 tensorflow==2.11.0
-tensorflow-io==0.27.0
+tensorflow-io==0.28.0
 tensorflow-estimator==2.11.0
 termcolor==2.1.1
 torch==1.13.0

--- a/src/common/enumerations.py
+++ b/src/common/enumerations.py
@@ -17,6 +17,38 @@
 
 from enum import Enum
 
+class StorageType(Enum):
+    """
+    Different types of underlying storage
+    """
+    LOCAL_FS = 'local_fs'
+    PARALLEL_FS = 'parallel_fs'
+    S3 = 's3'
+
+    def __str__(self):
+        return self.value
+
+class MetadataType(Enum):
+    """
+    Different types of storage metadata
+    """
+    FILE = 'file'
+    DIRECTORY = 'directory'
+    S3_OBJECT = 's3_object'
+
+    def __str__(self):
+        return self.value
+
+class NamespaceType(Enum):
+    """
+    Different types of Storage Namespace
+    """
+    FLAT = 'flat'
+    HIERARCHICAL = 'Hierarchical'
+
+    def __str__(self):
+        return self.value
+
 class DatasetType(Enum):
     """
     Training and Validation

--- a/src/data_generator/csv_generator.py
+++ b/src/data_generator/csv_generator.py
@@ -45,7 +45,7 @@ class CSVGenerator(DataGenerator):
         for i in range(0, int(self.total_files_to_generate)):
             if i % self.comm_size == self.my_rank:
                 progress(i+1, self.total_files_to_generate, "Generating CSV Data")
-                out_path_spec = self._file_list[i]
+                out_path_spec = self.storage.get_uri(self._file_list[i])
                 df = pd.DataFrame(data=records)
                 compression = None
                 if self.compression != Compression.NONE:

--- a/src/data_generator/data_generator.py
+++ b/src/data_generator/data_generator.py
@@ -18,8 +18,8 @@
 from abc import ABC, abstractmethod
 
 from src.utils.config import ConfigArguments
+from src.storage.storage_factory import StorageFactory
 import math
-import os
 from mpi4py import MPI
 from shutil import copyfile
 import numpy as np
@@ -48,19 +48,21 @@ class DataGenerator(ABC):
         self.num_subfolders_train = self._args.num_subfolders_train
         self.num_subfolders_eval = self._args.num_subfolders_eval
         self.format = self._args.format
+        self.storage = StorageFactory().get_storage(self._args.storage_type, self._args.storage_root,
+                                                                        self._args.framework)
 
     @abstractmethod
     def generate(self):
         if self.my_rank == 0:
-            os.makedirs(self.data_dir, exist_ok=True)
-            os.makedirs(self.data_dir + "/train/", exist_ok=True)
-            os.makedirs(self.data_dir + "/valid/", exist_ok=True)
+            self.storage.create_node(self.data_dir, exist_ok=True)
+            self.storage.create_node(self.data_dir + "/train/", exist_ok=True)
+            self.storage.create_node(self.data_dir + "/valid/", exist_ok=True)
             if self.num_subfolders_train > 1: 
                 for i in range(self.num_subfolders_train):
-                    os.makedirs(self.data_dir + "/train/%d"%i, exist_ok=True)
+                    self.storage.create_node(self.data_dir + "/train/%d"%i, exist_ok=True)
             if self.num_subfolders_eval > 1: 
                 for i in range(self.num_subfolders_eval):
-                    os.makedirs(self.data_dir + "/valid/%d"%i, exist_ok=True)
+                    self.storage.create_node(self.data_dir + "/valid/%d"%i, exist_ok=True)
             logging.info(f"{utcnow()} Generating dataset in {self.data_dir}/train and {self.data_dir}/valid")
             logging.info(f"{utcnow()} Number of files for training dataset: {self.num_files_train}")
             logging.info(f"{utcnow()} Number of files for validation dataset: {self.num_files_eval}")

--- a/src/data_generator/hdf5_generator.py
+++ b/src/data_generator/hdf5_generator.py
@@ -43,7 +43,7 @@ class HDF5Generator(DataGenerator):
         record_labels = [0] * self.num_samples
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
             progress(i, self.total_files_to_generate, "Generating HDF5 Data")
-            out_path_spec = self._file_list[i]
+            out_path_spec = self.storage.get_uri(self._file_list[i])
             hf = h5py.File(out_path_spec, 'w')
             chunks = None
             if self.enable_chunking:

--- a/src/data_generator/jpeg_generator.py
+++ b/src/data_generator/jpeg_generator.py
@@ -46,6 +46,6 @@ class JPEGGenerator(DataGenerator):
             img = im.fromarray(records)
             if self.my_rank == 0 and i % 100 == 0:
                 logging.info(f"Generated file {i}/{self.total_files_to_generate}")
-            out_path_spec = self._file_list[i]
+            out_path_spec = self.storage.get_uri(self._file_list[i])
             progress(i+1, self.total_files_to_generate, "Generating JPEG Data")
             img.save(out_path_spec, format='JPEG', bits=8)

--- a/src/data_generator/npz_generator.py
+++ b/src/data_generator/npz_generator.py
@@ -40,7 +40,7 @@ class NPZGenerator(DataGenerator):
         records = random.random((self._dimension, self._dimension, self.num_samples))
         record_labels = [0] * self.num_samples
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
-            out_path_spec = self._file_list[i]
+            out_path_spec = self.storage.get_uri(self._file_list[i])
             progress(i+1, self.total_files_to_generate, "Generating NPZ Data")
             prev_out_spec = out_path_spec
             if self.compression != Compression.ZIP:

--- a/src/data_generator/png_generator.py
+++ b/src/data_generator/png_generator.py
@@ -40,7 +40,7 @@ class PNGGenerator(DataGenerator):
         if self.my_rank==0:
             logging.info(f"{utcnow()} Dimension of images: {dim} x {dim} x 3")
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
-            out_path_spec = self._file_list[i]
+            out_path_spec = self.storage.get_uri(self._file_list[i])
             records = random.randint(255, size=(dim, dim, 3), dtype=np.uint8)
             img = im.fromarray(records)
             if self.my_rank == 0 and i % 100 == 0:

--- a/src/data_generator/tf_generator.py
+++ b/src/data_generator/tf_generator.py
@@ -42,7 +42,7 @@ class TFRecordGenerator(DataGenerator):
         record_label = 0
         for i in range(self.my_rank, self.total_files_to_generate, self.comm_size):
             progress(i+1, self.total_files_to_generate, "Generating TFRecord Data")
-            out_path_spec = self._file_list[i]
+            out_path_spec = self.storage.get_uri(self._file_list[i])
             # Open a TFRecordWriter for the output-file.
             with tf.io.TFRecordWriter(out_path_spec) as writer:
                 for i in range(0, self.num_samples):

--- a/src/framework/framework.py
+++ b/src/framework/framework.py
@@ -87,3 +87,27 @@ class Framework(ABC):
     @abstractmethod
     def get_reader(self, dataset_type):
         pass
+
+    @abstractmethod
+    def is_nativeio_available(self):
+        pass
+    # Metadata APIs
+    def create_node(self, id, exist_ok=False):
+        return False
+
+    def get_node(self, id):
+        return None
+
+    def walk_node(self, id, use_pattern=False):
+        return None
+
+    def delete_node(self, id):
+        return False
+
+    # Data APIs
+    def put_data(self, id, data, offset=None, length=None):
+        return False
+
+    def get_data(self, id, data, offset=None, length=None):
+        return None
+

--- a/src/framework/torch_framework.py
+++ b/src/framework/torch_framework.py
@@ -28,6 +28,7 @@ from src.utils.utility import utcnow
 from time import sleep
 
 from src.reader.reader_factory import ReaderFactory
+from src.storage.storage_factory import StorageFactory
 
 HANDLED_FUNCTIONS = {}
 
@@ -57,6 +58,7 @@ class TorchFramework(Framework):
     def init_reader(self, format_type, data_loader=None):
         self.reader_train = ReaderFactory.get_reader(format_type, data_loader=data_loader, dataset_type=DatasetType.TRAIN)
         self.reader_valid = ReaderFactory.get_reader(format_type, data_loader=data_loader, dataset_type=DatasetType.VALID)
+        self.storage = StorageFactory().get_storage(self.args.storage_type, self.args.storage_root, self.args.framework)
 
     def get_type(self):
         return FrameworkType.PYTORCH
@@ -100,3 +102,6 @@ class TorchFramework(Framework):
             return self.reader_train
         else:
             return self.reader_valid
+
+    def is_nativeio_available(self):
+        return False

--- a/src/storage/file_storage.py
+++ b/src/storage/file_storage.py
@@ -1,0 +1,61 @@
+from abc import ABC, abstractmethod
+from src.storage.storage_handler import DataStorage, Namespace
+from src.common.enumerations import NamespaceType, MetadataType
+import os
+import glob
+import shutil
+
+class FileStorage(DataStorage):
+    """
+    Storage APIs for creating files.
+    """
+    def __init__(self, namespace, framework=None):
+        super().__init__(framework)
+        self.namespace = Namespace(namespace, NamespaceType.HIERARCHICAL)
+
+    def get_uri(self, id):
+        return os.path.join(self.namespace.name, id)
+
+    # Namespace APIs
+    def create_namespace(self, exist_ok=False):
+        os.makedirs(self.namespace.name, exist_ok=exist_ok)
+        return True
+
+    def get_namespace(self):
+        return self.namespace.name
+
+    # Metadata APIs
+    def create_node(self, id, exist_ok=False):
+        os.makedirs(self.get_uri(id), exist_ok=exist_ok)
+        return True
+
+    def get_node(self, id=""):
+        path = self.get_uri(id)
+        if os.path.exists(path):
+            if os.path.isdir(path):
+                return MetadataType.DIRECTORY
+            else:
+                return MetadataType.FILE
+        else:
+            return None
+
+    def walk_node(self, id, use_pattern=False):
+        if not use_pattern:
+            return os.listdir(self.get_uri(id))
+        else:
+            return glob.glob(self.get_uri(id))
+
+    def delete_node(self, id):
+        shutil.rmtree(self.get_uri(id))
+        return True
+
+    # TODO Handle partial read and writes
+    def put_data(self, id, data, offset=None, length=None):
+        with open(self.get_uri(id), "w") as fd:
+            fd.write(data)
+
+    def get_data(self, id, data, offset=None, length=None):
+        with open(self.get_uri(id), "r") as fd:
+            data = fd.read()
+        return data
+

--- a/src/storage/s3_storage.py
+++ b/src/storage/s3_storage.py
@@ -1,0 +1,38 @@
+from src.storage.storage_handler import DataStorage, Namespace
+from src.common.enumerations import NamespaceType, MetadataType
+import os
+
+class S3Storage(DataStorage):
+    """
+    Storage APIs for creating files.
+    """
+    def __init__(self, namespace, framework=None):
+        super().__init__(framework)
+        self.namespace = Namespace(namespace, NamespaceType.FLAT)
+
+    def get_uri(self, id):
+        return "s3://"+ os.path.join(self.namespace.name, id)
+
+    def create_namespace(self, exist_ok=False):
+        return True
+
+    def get_namespace(self):
+        return self.get_node(self.namespace.name)
+
+    def create_node(self, id, exist_ok=False):
+        return super().create_node(self.get_uri(id), exist_ok)
+
+    def get_node(self, id=""):
+        return super().get_node(self.get_uri(id))
+
+    def walk_node(self, id, use_pattern=False):
+        return super().walk_node(self.get_uri(id), use_pattern)
+
+    def delete_node(self, id):
+        return super().delete_node(self.get_uri(id))
+
+    def put_data(self, id, data, offset=None, length=None):
+        return super().put_data(self.get_uri(id), data, offset, length)
+
+    def get_data(self, id, data, offset=None, length=None):
+        return super().get_data(self.get_uri(id), data, offset, length)

--- a/src/storage/storage_factory.py
+++ b/src/storage/storage_factory.py
@@ -1,0 +1,17 @@
+from src.storage.file_storage import FileStorage
+from src.storage.s3_storage import S3Storage
+from src.common.enumerations import StorageType
+from src.common.error_code import ErrorCodes
+
+class StorageFactory(object):
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_storage(storage_type, namespace, framework=None):
+        if storage_type == StorageType.LOCAL_FS:
+            return FileStorage(namespace, framework)
+        elif storage_type == StorageType.S3:
+            return S3Storage(namespace, framework)
+        else:
+            raise Exception(str(ErrorCodes.EC1001))

--- a/src/storage/storage_handler.py
+++ b/src/storage/storage_handler.py
@@ -1,0 +1,109 @@
+from abc import ABC, abstractmethod
+from src.framework.framework_factory import FrameworkFactory
+from src.utils.config import ConfigArguments
+
+class Namespace:
+    def __init__(self, name, type):
+        self.name = name
+        self.type = type
+
+class DataStorage(ABC):
+    def __init__(self, framework=None):
+        self._args = ConfigArguments.get_instance()
+        if framework is not None:
+            self.framework = FrameworkFactory().get_framework(self._args.framework, profiling=False)
+            self.is_framework_nativeio_available = self.framework.is_nativeio_available()
+        else:
+            self.framework = None
+            self.is_framework_nativeio_available = False
+
+    @abstractmethod
+    def get_uri(self, id):
+        """
+            This method returns URI of an id based on the implemented file system.
+            eg: For a file in S3, s3:// has to be prefixed to the file name.
+            eg: For a file in hdfs, hdfs:// has to be prefixed to the file name.
+        """
+        pass
+
+   
+    # Namespace APIs
+    @abstractmethod
+    def create_namespace(self, exist_ok=False):
+        """
+            This method creates the namespace for the storage which refers to the 
+            mount point of the storage. Eg: For files, namespace refers to the root directoy
+            where input and checkpoint directories are created. For Objects, namespace refers
+            to the bucket where input and checkpoint directories are created.
+        """
+        pass
+
+    @abstractmethod
+    def get_namespace(self):
+        """
+            This method returns the namespace of the storage.
+        """
+        pass
+
+    # Metadata APIs
+    @abstractmethod
+    def create_node(self, id, exist_ok=False):
+        """
+            This method creates a node within the storage namespace. 
+            For files/objects, nodes refer to the subdirectories.
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.create_node(id, exist_ok)
+        return True
+
+    @abstractmethod
+    def get_node(self, id):
+        """
+            This method returns the node info for a specific node id. 
+            For Files/Objects, it returns node type if node is a
+            file or directory
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.get_node(id)
+        return None
+
+    @abstractmethod
+    def walk_node(self, id, use_pattern=False):
+        """
+            This method lists the sub nodes under the specified node
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.walk_node(id, use_pattern)
+        return None
+
+    @abstractmethod
+    def delete_node(self, id):
+        """
+            This method deletes a specified node
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.delete_node(id)
+        return False
+
+    
+    # Data APIs
+    def put_data(self, id, data, offset=None, length=None):
+        """
+            This method adds data content to a node.
+            eg: For files, this method writes data to a file.
+                For objects, this method writes data to a object
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.put_data(id, data, offset, length)
+        return False
+    
+    def get_data(self, id, data, offset=None, length=None):
+        """
+            This method retrieves data content of a node.
+            eg: For files, this method returns file data.
+                For objects, this method returns object data.
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.get_data(id, data, offset, length)
+        return None
+

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -16,7 +16,7 @@
 """
 
 from typing import List, ClassVar
-from src.common.enumerations import FormatType, Shuffle, ReadType, FileAccess, Compression, FrameworkType, DataLoaderType, Profiler
+from src.common.enumerations import StorageType, FormatType, Shuffle, ReadType, FileAccess, Compression, FrameworkType, DataLoaderType, Profiler
 from dataclasses import dataclass, field
 import hydra
 import os
@@ -37,6 +37,10 @@ class ConfigArguments:
     shuffle_size: int = 1024
     sample_shuffle: Shuffle =Shuffle.OFF
     read_type: ReadType = ReadType.ON_DEMAND
+    file_access: FileAccess = FileAccess.MULTI
+    # Set root as the current directory by default
+    storage_root: str = "./"
+    storage_type: StorageType = StorageType.LOCAL_FS
     record_length: int = 64 * 1024
     num_files_train: int = 8 
     num_samples_per_file: int = 1
@@ -114,6 +118,13 @@ def LoadConfig(args, config):
         as a way to do model specific setting. 
         '''
         args.model = config['model']
+
+    if 'storage' in config:
+        if 'storage_type' in config['storage']:
+            args.storage_type = StorageType(config['storage']['storage_type'])
+        if 'storage_root' in config['storage']:
+            args.storage_root = config['storage']['storage_root']
+
     # dataset related settings
     if 'dataset' in config:
         if 'record_length' in config['dataset']:
@@ -126,6 +137,7 @@ def LoadConfig(args, config):
             args.num_samples_per_file = config['dataset']['num_samples_per_file']
         if 'data_folder' in config['dataset']:
             args.data_folder = config['dataset']['data_folder']
+            args.data_folder = args.data_folder.rstrip('/')
         if 'num_subfolders_train' in config['dataset']:
             args.num_subfolders_train = config['dataset']['num_subfolders_train']
         if 'num_subfolders_eval' in config['dataset']:
@@ -201,6 +213,7 @@ def LoadConfig(args, config):
     if 'checkpoint' in config:
         if 'checkpoint_folder' in config['checkpoint']:
             args.checkpoint_folder = config['checkpoint']['checkpoint_folder']
+            args.checkpoint_folder = args.checkpoint_folder.rstrip('/')
         if 'checkpoint_after_epoch' in config['checkpoint']:
             args.checkpoint_after_epoch = config['checkpoint']['checkpoint_after_epoch']
         if 'epochs_between_checkpoints' in config['checkpoint']:


### PR DESCRIPTION
This PR adds Storage interface in DLIO. This adds support for multiple storage backends like S3 objects etc 

**There is no change in current DLIO functionality or  behaviour with this PR** 

This PR adds

1. Adds one new config parameter in Dataset- `storage_type`. The default is `local_fs`.  The other option is `S3`
2. New Storage Interface is created for all filesystem operations 
3. For any benchmark, data dir and checkpoint dir has to be created on the storage system under test. While output folder is stored on the local client system itself.  So,  for all operations on data_dir and checkpoint_dir uses storage system interface.
4. Currently used local file system calls(using os module) are moved to file_storage.py. S3 apis are implemented in s3_storage.py
5. Changes are made only to TF framework as tf.io package can handle multiple system backends.  Support for Torch has to be added in a separate PR

---------------------------------

For @zhenghh04,  I am adding the design details as per discussion with @hariharan-devarajan 

A new storage interface is created which has generic concepts that can apply well for various storage backends. 
 
   Each storage has `namespace` with set of `nodes`. 
   `Namespace` is the mount point of the storage. For files, it is the root directory where input and checkpoint directories are created. For Objects, namespace refers to the bucket where input and checkpoint directories are created
   `Nodes` refer to the entries within the namespace which can be a file/directory/object. It has an `id` which is the `path` in Files and `Key` in `Objects`.

For a workload, the storage interface can use the framework IO apis for metadata and data operations  if framework native apis are available. eg: TF has `tf.io` which provides IO support for different storage backends. But Pytorch doesn't have it.   We will add PyTorch framework support for S3 later. 