### PR TITLE
Minor fixes 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@ output/
 data/
 logs/
 data*/
+Dockerfile*
+hydra_log
+TODO.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,3 @@ logs/
 data*/
 Dockerfile*
 hydra_log
-TODO.md

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,17 +22,37 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest pytest-mpi pytest-subtests pytest-timeout
-    - name: pytest-seq
+    - name: test_gen_data
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        python3 -m pytest -v 
+        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_gen_data
 
-    - name: pytest-mpi
+    - name: test_train
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 -m pytest -v --with-mpi
+        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_train
+    - name: test_checkpoint_epoch
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_checkpoint_epoch              
+    - name: test_checkpoint_step
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_checkpoint_step
+    - name: test_eval
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_eval
+    - name: test_multi_threads
+      run: |
+        touch __init__.py
+        export PYTHONPATH=./:$PYTHONPATH
+        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_multi_threads
     - name: test-tf-loader-npz
       run: |
         touch __init__.py

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,30 +21,18 @@ jobs:
         sudo apt-get install mpich
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest pytest-mpi pytest-subtests 
+        pip install pytest pytest-mpi pytest-subtests pytest-timeout
     - name: pytest-seq
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        python3 -m pytest -v -k test_gen_data
-        python3 -m pytest -v -k test_train
-        python3 -m pytest -v -k test_eval
-        python3 -m pytest -v -k test_checkpoint_epoch
-        python3 -m pytest -v -k test_checkpoint_step
-        python3 -m pytest -v -k test_multi_threads
-        python3 -m pytest -v -k test_iostat_profiling
+        python3 -m pytest -v 
 
     - name: pytest-mpi
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 -m pytest -v -k test_gen_data
-        mpirun -np 2 python3 -m pytest -v -k test_train
-        mpirun -np 2 python3 -m pytest -v -k test_eval
-        mpirun -np 2 python3 -m pytest -v -k test_checkpoint_epoch
-        mpirun -np 2 python3 -m pytest -v -k test_checkpoint_step
-        mpirun -np 2 python3 -m pytest -v -k test_multi_threads    - name: test-tf-loader-tfrecord
-        mpirun -np 2 python3 -m pytest -v -k test_iostat_profiling
+        mpirun -np 2 python3 -m pytest -v --with-mpi
     - name: test-tf-loader-npz
       run: |
         touch __init__.py

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -26,39 +26,39 @@ jobs:
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_gen_data
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_gen_data
 
     - name: test_train
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_train
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_train
     - name: test_checkpoint_epoch
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_checkpoint_epoch              
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_checkpoint_epoch              
     - name: test_checkpoint_step
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_checkpoint_step
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_checkpoint_step
     - name: test_eval
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_eval
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_eval
     - name: test_multi_threads
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_multi_threads
-    - name: test-tf-loader-npz
+        RDMAV_FORK_SAFE=1 mpirun -np 2 python3 tests/dlio_benchmark_test.py -k test_multi_threads
+    - name: test-tf-loader-tfrecord
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -n 2 python ./src/dlio_benchmark.py workload=resnet50 ++workload.dataset.num_files_train=64 ++workload.workflow.train=False ++workload.workflow.generate_data=True  ++workload.dataset.num_files_train=16 ++workload.dataset.num_samples_per_file=16
-        mpirun -n 2 python ./src/dlio_benchmark.py workload=resnet50 ++workload.dataset.num_files_train=64 ++workload.workflow.train=True ++workload.workflow.generate_data=False  ++workload.dataset.num_files_train=16 ++workload.dataset.num_samples_per_file=16
+        RDMAV_FORK_SAFE=1 mpirun -n 2 python ./src/dlio_benchmark.py workload=resnet50 ++workload.dataset.num_files_train=64 ++workload.workflow.train=False ++workload.workflow.generate_data=True  ++workload.dataset.num_files_train=16 ++workload.dataset.num_samples_per_file=16
+        RDMAV_FORK_SAFE=1 mpirun -n 2 python ./src/dlio_benchmark.py workload=resnet50 ++workload.dataset.num_files_train=64 ++workload.workflow.train=True ++workload.workflow.generate_data=False  ++workload.dataset.num_files_train=16 ++workload.dataset.num_samples_per_file=16
         output=`ls -d ./hydra_log/resnet50/* | tail -1`
         python ./src/dlio_postprocessor.py --output-folder=${output}
         cat ${output}/*.txt
@@ -66,8 +66,8 @@ jobs:
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=False ++workload.workflow.generate_data=True ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
-        mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=True ++workload.workflow.generate_data=False ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
+        RDMAV_FORK_SAFE=1 mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=False ++workload.workflow.generate_data=True ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
+        RDMAV_FORK_SAFE=1 mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=True ++workload.workflow.generate_data=False ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
         output=`ls -d ./hydra_log/unet3d/* | tail -1`
         python ./src/dlio_postprocessor.py --output-folder=${output}
         cat ${output}/*.txt
@@ -75,8 +75,8 @@ jobs:
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.framework=tensorflow ++workload.data_reader.data_loader=tensorflow ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=False ++workload.workflow.generate_data=True ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
-        mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.framework=tensorflow ++workload.data_reader.data_loader=tensorflow ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=True ++workload.workflow.generate_data=False ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
+        RDMAV_FORK_SAFE=1 mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.framework=tensorflow ++workload.data_reader.data_loader=tensorflow ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=False ++workload.workflow.generate_data=True ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
+        RDMAV_FORK_SAFE=1 mpirun -n 2 python ./src/dlio_benchmark.py workload=unet3d ++workload.framework=tensorflow ++workload.data_reader.data_loader=tensorflow ++workload.train.computation_time=0.05 ++workload.evaluation.eval_time=0.01 ++workload.train.epochs=2 ++workload.workflow.train=True ++workload.workflow.generate_data=False ++workload.dataset.num_files_train=16 ++workload.dataset.num_files_eval=4
         output=`ls -d ./hydra_log/unet3d/* | tail -1`
         python ./src/dlio_postprocessor.py --output-folder=${output}
         cat ${output}/*.txt

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -26,13 +26,26 @@ jobs:
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        python3 -m pytest -v
+        python3 -m pytest -v -k test_gen_data
+        python3 -m pytest -v -k test_train
+        python3 -m pytest -v -k test_eval
+        python3 -m pytest -v -k test_checkpoint_epoch
+        python3 -m pytest -v -k test_checkpoint_step
+        python3 -m pytest -v -k test_multi_threads
+        python3 -m pytest -v -k test_iostat_profiling
+
     - name: pytest-mpi
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH
-        mpirun -np 2 python3 -m pytest  --with-mpi
-    - name: test-tf-loader-tfrecord
+        mpirun -np 2 python3 -m pytest -v -k test_gen_data
+        mpirun -np 2 python3 -m pytest -v -k test_train
+        mpirun -np 2 python3 -m pytest -v -k test_eval
+        mpirun -np 2 python3 -m pytest -v -k test_checkpoint_epoch
+        mpirun -np 2 python3 -m pytest -v -k test_checkpoint_step
+        mpirun -np 2 python3 -m pytest -v -k test_multi_threads    - name: test-tf-loader-tfrecord
+        mpirun -np 2 python3 -m pytest -v -k test_iostat_profiling
+
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -45,7 +45,7 @@ jobs:
         mpirun -np 2 python3 -m pytest -v -k test_checkpoint_step
         mpirun -np 2 python3 -m pytest -v -k test_multi_threads    - name: test-tf-loader-tfrecord
         mpirun -np 2 python3 -m pytest -v -k test_iostat_profiling
-
+    - name: test-tf-loader-npz
       run: |
         touch __init__.py
         export PYTHONPATH=./:$PYTHONPATH

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker build -t dlio .
 docker run -t dlio python ./src/dlio_benchmark.py ++workload.workflow.generate_data=True
 ``` 
 
-You can also pull rebuilt container from docker hub: 
+You can also pull rebuilt container from docker hub (might not reflect the most recent change of the code): 
 ```bash
 docker docker.io/zhenghh04/dlio:latest
 docker run -t docker.io/zhenghh04/dlio:latest python ./src/dlio_benchmark.py ++workload.workflow.generate_data=True

--- a/configs/workload/bert.yaml
+++ b/configs/workload/bert.yaml
@@ -20,7 +20,7 @@ train:
  computation_time: 0.968
  total_training_steps: 5000
  
-data_reader:
+reader:
  data_loader: tensorflow
  read_threads: 1
  computation_threads: 8

--- a/configs/workload/cosmoflow.yaml
+++ b/configs/workload/cosmoflow.yaml
@@ -13,7 +13,7 @@ dataset:
  record_length: 131072
  batch_size: 1
 
-data_reader:
+reader:
  data_loader: tensorflow
  computation_threads: 8
  read_threads: 8

--- a/configs/workload/resnet50.yaml
+++ b/configs/workload/resnet50.yaml
@@ -13,7 +13,7 @@ dataset:
  data_folder: data/resnet50
  format: tfrecord
  
-data_loader:
+reader:
  data_loader: tensorflow
  read_threads: 8
  computation_threads: 8

--- a/configs/workload/unet3d.yaml
+++ b/configs/workload/unet3d.yaml
@@ -19,7 +19,7 @@ dataset:
   record_length: 147000000
   keep_files: True
   
-data_reader: 
+reader: 
   data_loader: pytorch
 
 train:

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -23,7 +23,6 @@ The characteristics of a workload is specified through a YAML file. This file wi
     num_samples_per_file: 1
     batch_size: 4
     batch_size_eval: 1
-    file_access: multi
     record_length: 1145359
     keep_files: True
   
@@ -191,9 +190,6 @@ data_reader
    * - read_shuffle
      - off
      - [seed|random|off] whether and how to shuffle the dataset
-   * - file_access
-     - multi
-     - multi - file per process; shared - independent access to a single shared file; collective - collective I/O access to a single shared file
    * - transfer_size
      - 1048576
      - transfer size in byte for tensorflow data loader. 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.9
 [options.packages.find]
 where = src
 

--- a/src/common/enumerations.py
+++ b/src/common/enumerations.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/common/enumerations.py
+++ b/src/common/enumerations.py
@@ -118,6 +118,7 @@ class FileAccess(Enum):
     """
     MULTI = 'multi'
     SHARED = 'shared'
+    # TO(HZ): I see currently, this collective mode is not used. It might be good to separate it out
     COLLECTIVE = 'collective'
 
     def __str__(self):

--- a/src/common/error_code.py
+++ b/src/common/error_code.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/computation/asynchronous_computation.py
+++ b/src/computation/asynchronous_computation.py
@@ -1,5 +1,5 @@
 '''
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/computation/computation_factory.py
+++ b/src/computation/computation_factory.py
@@ -1,5 +1,5 @@
 '''
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/computation/computation_handler.py
+++ b/src/computation/computation_handler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/computation/no_computation.py
+++ b/src/computation/no_computation.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/computation/synchronous_computation.py
+++ b/src/computation/synchronous_computation.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/csv_generator.py
+++ b/src/data_generator/csv_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
    
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/data_generator.py
+++ b/src/data_generator/data_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/generator_factory.py
+++ b/src/data_generator/generator_factory.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/hdf5_generator.py
+++ b/src/data_generator/hdf5_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/jpeg_generator.py
+++ b/src/data_generator/jpeg_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/jpeg_generator.py
+++ b/src/data_generator/jpeg_generator.py
@@ -39,8 +39,8 @@ class JPEGGenerator(DataGenerator):
         super().generate()
         dim = int(np.sqrt(self.record_size/3.0))
         record_labels = [0] 
-        logging.info(f"dimension of images: {dim} x {dim} x 3")
-
+        if self.my_rank==0:
+            logging.info(f"{utcnow()} Dimension of images: {dim} x {dim} x 3")
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
             records = random.randint(255, size=(dim, dim, 3), dtype=np.uint8)
             img = im.fromarray(records)

--- a/src/data_generator/jpeg_generator.py
+++ b/src/data_generator/jpeg_generator.py
@@ -22,7 +22,7 @@ import logging
 import numpy as np
 from numpy import random
 
-from src.utils.utility import progress
+from src.utils.utility import progress, utcnow
 from shutil import copyfile
 import PIL.Image as im
 """

--- a/src/data_generator/npz_generator.py
+++ b/src/data_generator/npz_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/npz_generator.py
+++ b/src/data_generator/npz_generator.py
@@ -41,7 +41,7 @@ class NPZGenerator(DataGenerator):
         record_labels = [0] * self.num_samples
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
             out_path_spec = self._file_list[i]
-            progress(i+1, self.total_files_to_generate, f"[INFO] {utcnow()} Generating NPZ Data")
+            progress(i+1, self.total_files_to_generate, "Generating NPZ Data")
             prev_out_spec = out_path_spec
             if self.compression != Compression.ZIP:
                 np.savez(out_path_spec, x=records, y=record_labels)

--- a/src/data_generator/npz_generator.py
+++ b/src/data_generator/npz_generator.py
@@ -22,7 +22,7 @@ import logging
 import numpy as np
 from numpy import random
 
-from src.utils.utility import progress
+from src.utils.utility import progress, utcnow
 from shutil import copyfile
 
 """
@@ -40,10 +40,8 @@ class NPZGenerator(DataGenerator):
         records = random.random((self._dimension, self._dimension, self.num_samples))
         record_labels = [0] * self.num_samples
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
-            if self.my_rank == 0 and i % 100 == 0:
-                logging.info(f"Generated file {i}/{self.total_files_to_generate}")
             out_path_spec = self._file_list[i]
-            progress(i+1, self.total_files_to_generate, "Generating NPZ Data")
+            progress(i+1, self.total_files_to_generate, f"[INFO] {utcnow()} Generating NPZ Data")
             prev_out_spec = out_path_spec
             if self.compression != Compression.ZIP:
                 np.savez(out_path_spec, x=records, y=record_labels)

--- a/src/data_generator/png_generator.py
+++ b/src/data_generator/png_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/png_generator.py
+++ b/src/data_generator/png_generator.py
@@ -37,7 +37,8 @@ class PNGGenerator(DataGenerator):
         super().generate()
         dim = int(np.sqrt(self.record_size/3.0))
         record_labels = [0] 
-        logging.info(f"dimension of images: {dim} x {dim} x 3")
+        if self.my_rank==0:
+            logging.info(f"{utcnow()} Dimension of images: {dim} x {dim} x 3")
         for i in range(self.my_rank, int(self.total_files_to_generate), self.comm_size):
             out_path_spec = self._file_list[i]
             records = random.randint(255, size=(dim, dim, 3), dtype=np.uint8)

--- a/src/data_generator/png_generator.py
+++ b/src/data_generator/png_generator.py
@@ -22,7 +22,7 @@ import logging
 import numpy as np
 from numpy import random
 
-from src.utils.utility import progress
+from src.utils.utility import progress, utcnow
 from shutil import copyfile
 import PIL.Image as im
 

--- a/src/data_generator/tf_generator.py
+++ b/src/data_generator/tf_generator.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/data_generator/tf_generator.py
+++ b/src/data_generator/tf_generator.py
@@ -43,7 +43,6 @@ class TFRecordGenerator(DataGenerator):
         for i in range(self.my_rank, self.total_files_to_generate, self.comm_size):
             progress(i+1, self.total_files_to_generate, "Generating TFRecord Data")
             out_path_spec = self._file_list[i]
-            logging.info(f"{utcnow()} Generating TFRecord {out_path_spec}")
             # Open a TFRecordWriter for the output-file.
             with tf.io.TFRecordWriter(out_path_spec) as writer:
                 for i in range(0, self.num_samples):

--- a/src/dlio_benchmark.py
+++ b/src/dlio_benchmark.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/dlio_benchmark.py
+++ b/src/dlio_benchmark.py
@@ -224,6 +224,7 @@ class DLIOBenchmark(object):
         self.stats.start_block(epoch, block)
         t0 = time()
         for batch in self.framework.get_reader(dataset_type=DatasetType.TRAIN).next():
+            logging.debug(f"{utcnow()} Rank {self.my_rank} batch: {batch[:][1:]}")
             self.stats.batch_loaded(epoch, overall_step, block, t0)
             self.framework.barrier()
             # Log a new block, unless it's the first one which we've already logged before the loop
@@ -278,6 +279,7 @@ class DLIOBenchmark(object):
         On each epoch, it prepares dataset for reading, it trains, and finalizes the dataset.
         If evaluation is enabled, it reads the eval dataset, performs evaluation and finalizes.
         """
+        self.start_timestamp=time()
         if not self.generate_only:
             # Print out the expected number of steps for each epoch and evaluation
             if self.my_rank == 0:

--- a/src/dlio_benchmark.py
+++ b/src/dlio_benchmark.py
@@ -33,7 +33,7 @@ import warnings
 warnings.filterwarnings("ignore", category=UserWarning)
 
 from dataclasses import dataclass
-from src.utils.utility import utcnow
+from src.utils.utility import utcnow, measure_performance
 from omegaconf import DictConfig, OmegaConf
 from src.utils.statscounter import StatsCounter
 from hydra.core.config_store import ConfigStore
@@ -353,7 +353,7 @@ class DLIOBenchmark(object):
             logging.info(f"{utcnow()} Saved outputs in {self.output_folder}")
         self.framework.barrier()
 
-
+@measure_performance
 @hydra.main(version_base=None, config_path="../configs", config_name="config")
 def main(cfg : DictConfig) -> None:
     """

--- a/src/dlio_benchmark.py
+++ b/src/dlio_benchmark.py
@@ -349,9 +349,9 @@ class DLIOBenchmark(object):
             
             # Save collected stats to disk
             self.stats.save_data()
-        if self.my_rank==0:
-            logging.info(f"{utcnow()} Saved outputs in {self.output_folder}")
         self.framework.barrier()
+        if self.my_rank==0:
+            logging.info(f"{utcnow()} Saved outputs in {self.output_folder}")        
 
 @measure_performance
 @hydra.main(version_base=None, config_path="../configs", config_name="config")

--- a/src/dlio_postprocessor.py
+++ b/src/dlio_postprocessor.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/framework/framework.py
+++ b/src/framework/framework.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/framework/framework_factory.py
+++ b/src/framework/framework_factory.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/framework/tf_framework.py
+++ b/src/framework/tf_framework.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
    
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/framework/torch_framework.py
+++ b/src/framework/torch_framework.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
    
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/profiler/darshan_profiler.py
+++ b/src/profiler/darshan_profiler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/profiler/io_profiler.py
+++ b/src/profiler/io_profiler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/profiler/iostat_profiler.py
+++ b/src/profiler/iostat_profiler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/profiler/iostat_profiler.py
+++ b/src/profiler/iostat_profiler.py
@@ -18,7 +18,13 @@
 from src.profiler.io_profiler import IOProfiler
 import os
 import signal
-import subprocess as sp
+import subprocess as sp 
+
+def kill(proc_pid):
+    process = psutil.Process(proc_pid)
+    for proc in process.children(recursive=True):
+        proc.kill()
+    process.kill()
 
 class IostatProfiler(IOProfiler):
     __instance = None
@@ -67,3 +73,4 @@ class IostatProfiler(IOProfiler):
             self.process.send_signal(signal.SIGINT) 
             # Might need a timeout here in case it hangs forever
             self.process.wait()
+

--- a/src/profiler/no_profiler.py
+++ b/src/profiler/no_profiler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/profiler/profiler_factory.py
+++ b/src/profiler/profiler_factory.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/profiler/tf_profiler.py
+++ b/src/profiler/tf_profiler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/csv_reader.py
+++ b/src/reader/csv_reader.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/hdf5_reader.py
+++ b/src/reader/hdf5_reader.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/hdf5_stimulate.py
+++ b/src/reader/hdf5_stimulate.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/npz_reader.py
+++ b/src/reader/npz_reader.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/reader_factory.py
+++ b/src/reader/reader_factory.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/reader_handler.py
+++ b/src/reader/reader_handler.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/reader_handler.py
+++ b/src/reader/reader_handler.py
@@ -40,7 +40,7 @@ class FormatReader(ABC):
         self.record_size = self._args.record_length
         self.prefetch_size = self._args.prefetch_size
         self.transfer_size = self._args.transfer_size
-        self.file_access = self._args.file_access
+        
         self.my_rank = self._args.my_rank
         self.comm_size = self._args.comm_size
         self.eval_enabled = self._args.do_eval
@@ -65,7 +65,10 @@ class FormatReader(ABC):
                                                           self._args.do_profiling)
 
         # We do this here so we keep the same evaluation files every epoch
-
+        if self.num_files_train > 1 or self.num_samples == 1:
+            self.file_acess = FileAccess.MULTI
+        else:
+            self.file_acess = FileAccess.SHARED
         if self.dataset_type == DatasetType.TRAIN:
             filenames = os.listdir(self.data_dir + "/train/")
             if not os.path.isfile(self.data_dir + "/train/" + filenames[0]):

--- a/src/reader/reader_handler.py
+++ b/src/reader/reader_handler.py
@@ -75,16 +75,20 @@ class FormatReader(ABC):
 
             num_files = self.num_files_train
             self.batch_size = self.batch_size_train
+            assert len(fullpaths) == num_files, f"Expected {num_files} training files but {len(fullpaths)} found. Ensure data was generated correctly."            
         elif self.dataset_type == DatasetType.VALID:
             filenames = os.listdir(self.data_dir + "/valid/")
-            if not os.path.isfile(self.data_dir + "/valid/" + filenames[0]):
-                fullpaths=glob.glob(self.data_dir + "/valid/*/*")
+            if (len(filenames)>0):
+                if not os.path.isfile(self.data_dir + "/valid/" + filenames[0]):
+                    fullpaths=glob.glob(self.data_dir + "/valid/*/*")
+                else:
+                    fullpaths = [os.path.join(self.data_dir+"/valid/", entry) for entry in filenames]
+                num_files = self.num_files_eval
+                self.batch_size = self.batch_size_eval
+                assert len(fullpaths) == num_files, f"Expected {num_files} validation files but {len(fullpaths)} found. Ensure data was generated correctly."
             else:
-                fullpaths = [os.path.join(self.data_dir+"/valid/", entry) for entry in filenames]
-            num_files = self.num_files_eval
-            self.batch_size = self.batch_size_eval
+                fullpaths=[]
 
-        assert len(fullpaths) == num_files, f"Expected {num_files} training files but {len(fullpaths)} found. Ensure data was generated correctly."
         self._file_list = fullpaths
         self._local_file_list = self._file_list[self.my_rank::self.comm_size]
 

--- a/src/reader/tf_data_loader_reader.py
+++ b/src/reader/tf_data_loader_reader.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/tf_data_loader_reader.py
+++ b/src/reader/tf_data_loader_reader.py
@@ -104,7 +104,12 @@ class TFDataLoaderReader(FormatReader):
         
         dataset = tf.data.Dataset.from_tensor_slices(self._file_list)
         dataset = dataset.shard(num_shards=self.comm_size, index=self.my_rank)
+        if self.read_threads==0:
+            if self._args.my_rank==0:
+                logging.warning(f"{utcnow()} `read_threads` is set to be 0 for tf.data loader. We change it to tf.data.AUTOTUNE")
+            self.read_threads=tf.data.AUTOTUNE
         dataset = dataset.map(self._tf_parse_function, num_parallel_calls=self.read_threads)
+        #dataset = dataset.interleave(self._tf_parse_function, num_parallel_calls=self.read_threads)
 
         if self.memory_shuffle != Shuffle.OFF:
             if self.memory_shuffle == Shuffle.SEED:

--- a/src/reader/tf_data_loader_reader.py
+++ b/src/reader/tf_data_loader_reader.py
@@ -32,7 +32,7 @@ def timeit(func):
         begin = tf.timestamp()
         x = func(*args, **kwargs)
         end = tf.timestamp()
-        return x, start, end, os.getpid()
+        return x, begin, end, os.getpid()
     return wrapper
 
 @tf.function    

--- a/src/reader/tf_reader.py
+++ b/src/reader/tf_reader.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/tf_reader.py
+++ b/src/reader/tf_reader.py
@@ -18,7 +18,7 @@ import math
 import logging
 from time import time
 
-from src.utils.utility import utcnow
+from src.utils.utility import utcnow, timeit
 from src.common.enumerations import Shuffle
 from src.reader.reader_handler import FormatReader
 import tensorflow as tf
@@ -37,7 +37,7 @@ class TFReader(FormatReader):
 
     # TODO: DLIO assumes the tfrecord files to contain image/label pairs.
     # This is not always the case, e.g. in BERT, each record is more complex,
-    # consisting of 6 lists and a label. Same for DLRM. 
+    # consisting of 6 lists and a label. Same for DLRM.
     def _tf_parse_function(self, serialized):
         """
         performs deserialization of the tfrecord.

--- a/src/reader/tf_reader.py
+++ b/src/reader/tf_reader.py
@@ -71,6 +71,10 @@ class TFReader(FormatReader):
         """
         # superclass function initializes the file list
         super().read(epoch_number)
+        if self.read_threads==0:
+            if self._args.my_rank==0:
+                logging.warning(f"{utcnow()} `read_threads` is set to be 0 for tf.data loader. We change it to tf.data.AUTOTUNE")
+            self.read_threads=tf.data.AUTOTUNE
         dataset = tf.data.TFRecordDataset(filenames=self._file_list,
                                           buffer_size=self.transfer_size,
                                           num_parallel_reads=self.read_threads)

--- a/src/reader/torch_data_loader_reader.py
+++ b/src/reader/torch_data_loader_reader.py
@@ -1,5 +1,5 @@
 """
-   Copyright © 2022, UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
    All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/reader/torch_data_loader_reader.py
+++ b/src/reader/torch_data_loader_reader.py
@@ -20,7 +20,7 @@ import numpy as np
 from time import time
 import os
 
-from src.utils.utility import utcnow
+from src.utils.utility import utcnow, timeit
 
 from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.distributed import DistributedSampler
@@ -51,8 +51,7 @@ def read_hdf5(f):
 
 def read_file(f):
     with open(f, mode='rb') as file: # b is important -> binary
-        fileContent = file.read()
-    return fileContent
+        return file.read()
 
 filereader={
     FormatType.JPEG: read_jpeg, 
@@ -77,7 +76,8 @@ class TorchDataset(Dataset):
             
         def __len__(self):
             return len(self.samples)
-        
+
+        @timeit
         def __getitem__(self, idx):
             logging.debug(f"{utcnow()} Rank {self.my_rank} reading {self.samples[idx]}")
             return self.read(self.samples[idx])

--- a/src/reader/torch_data_loader_reader.py
+++ b/src/reader/torch_data_loader_reader.py
@@ -97,9 +97,10 @@ class TorchDataLoaderReader(FormatReader):
         # superclass function shuffle the file list 
         super().read(epoch_number)
         do_shuffle = True if self.memory_shuffle != Shuffle.OFF else False
-        
-        dataset = TorchDataset(self._file_list, self.my_rank, self.format)
-        
+        if self._args.num_samples_per_file == 1:
+            dataset = TorchDataset(self._file_list, self.my_rank, self.format)
+        else:
+            raise Exception(f"Multiple sample per file is currently unsupported in PyTorch reader")
         # TODO: In image segmentation, the distributed sampler is not used during eval, we could parametrize this away if needed
         # This handles the partitioning between ranks
         sampler = DistributedSampler(dataset, 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -27,6 +27,7 @@ class ConfigArguments:
 
     # command line argument
     # Framework to use
+    model: str = "default"
     framework: FrameworkType = FrameworkType.TENSORFLOW
     # Dataset format, such as PNG, JPEG
     format: FormatType = FormatType.TFRECORD
@@ -107,6 +108,12 @@ def LoadConfig(args, config):
     '''
     if 'framework' in config:
         args.framework = FrameworkType(config['framework'])
+    if 'model' in config:
+        ''' 
+        most of the time, this won't change the benchmark. But in future we might use 
+        as a way to do model specific setting. 
+        '''
+        args.model = config['model']
     # dataset related settings
     if 'dataset' in config:
         if 'record_length' in config['dataset']:
@@ -146,7 +153,7 @@ def LoadConfig(args, config):
     reader=None
     if 'data_reader' in config:
         reader = config['data_reader']
-    elif 'data_reader' in config:
+    elif 'reader' in config:
         reader = config['reader']
     if reader is not None:
         if 'data_loader' in reader:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -36,7 +36,6 @@ class ConfigArguments:
     shuffle_size: int = 1024
     memory_shuffle: Shuffle =Shuffle.OFF
     read_type: ReadType = ReadType.ON_DEMAND
-    file_access: FileAccess = FileAccess.MULTI
     record_length: int = 64 * 1024
     num_files_train: int = 8 
     num_samples_per_file: int = 1
@@ -174,8 +173,6 @@ def LoadConfig(args, config):
             args.memory_shuffle = reader['memory_shuffle']
         if 'read_type' in reader:
             args.read_type = reader['read_type']
-        if 'file_access' in reader:
-            args.file_access = reader['file_access']
         if 'transfer_size' in reader:
             args.transfer_size = reader['transfer_size']
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -19,6 +19,7 @@ from src.common.enumerations import FormatType, Shuffle, ReadType, FileAccess, C
 from dataclasses import dataclass, field
 import hydra
 import os
+import logging
 
 @dataclass
 class ConfigArguments:
@@ -142,29 +143,34 @@ def LoadConfig(args, config):
             args.keep_files = config['dataset']['keep_files']
 
     # data loader
+    reader=None
     if 'data_reader' in config:
-        if 'data_loader' in config['data_reader']:
-            args.data_loader = DataLoaderType(config['data_reader']['data_loader'])
-        if 'read_threads' in config['data_reader']:
-            args.read_threads = config['data_reader']['read_threads']
-        if 'computatation_threads' in config['data_reader']:
-            args.computatation_threads = config['data_reader']['computatation_threads']
-        if 'prefetch' in config['data_reader']:
-            args.prefetch = config['data_reader']['prefetch']
-        if 'prefetch_size' in config['data_reader']:
-            args.prefetch_size = config['data_reader']['prefetch_size']
-        if 'read_shuffle' in config['data_reader']:
-            args.read_shuffle = config['data_reader']['read_shuffle']
-        if 'shuffle_size' in config['data_reader']:
-            args.shuffle_size = config['data_reader']['shuffle_size']
-        if 'memory_shuffle' in config['data_reader']:
-            args.memory_shuffle = config['data_reader']['memory_shuffle']
-        if 'read_type' in config['data_reader']:
-            args.read_type = config['data_reader']['read_type']
-        if 'file_access' in config['data_reader']:
-            args.file_access = config['data_reader']['file_access']
-        if 'transfer_size' in config['data_reader']:
-            args.transfer_size = config['data_reader']['transfer_size']
+        reader = config['data_reader']
+    elif 'data_reader' in config:
+        reader = config['reader']
+    if reader is not None:
+        if 'data_loader' in reader:
+            args.data_loader = DataLoaderType(reader['data_loader'])
+        if 'read_threads' in reader:
+            args.read_threads = reader['read_threads']
+        if 'computatation_threads' in reader:
+            args.computatation_threads = reader['computatation_threads']
+        if 'prefetch' in reader:
+            args.prefetch = reader['prefetch']
+        if 'prefetch_size' in reader:
+            args.prefetch_size = reader['prefetch_size']
+        if 'read_shuffle' in reader:
+            args.read_shuffle = reader['read_shuffle']
+        if 'shuffle_size' in reader:
+            args.shuffle_size = reader['shuffle_size']
+        if 'memory_shuffle' in reader:
+            args.memory_shuffle = reader['memory_shuffle']
+        if 'read_type' in reader:
+            args.read_type = reader['read_type']
+        if 'file_access' in reader:
+            args.file_access = reader['file_access']
+        if 'transfer_size' in reader:
+            args.transfer_size = reader['transfer_size']
 
     # training relevant setting
     if 'train' in config:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,5 +1,6 @@
 """
-   Copyright 2021 UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
+   All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/utils/statscounter.py
+++ b/src/utils/statscounter.py
@@ -1,4 +1,19 @@
+"""
+   Copyright (c) 2022, UChicago Argonne, LLC
+   All Rights Reserved
 
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
 from numpy import append
 from src.utils.config import ConfigArguments
 from src.utils.utility import utcnow

--- a/src/utils/utility.py
+++ b/src/utils/utility.py
@@ -21,6 +21,13 @@ from src.utils.config import ConfigArguments
 from time import time
 # UTC timestamp format with microsecond precision
 LOG_TS_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+from mpi4py import MPI
+
+def get_rank():
+    return MPI.COMM_WORLD.rank
+
+def get_size():
+    return MPI.COMM_WORLD.size
 
 def timeit(func):
     def wrapper(*args, **kwargs):
@@ -30,17 +37,19 @@ def timeit(func):
         return x, "%10.10f"%begin, "%10.10f"%end, os.getpid()
     return wrapper
 
-# Where does this print? I don't see it in the terminal
 def progress(count, total, status=''):
+    """
+    Printing a progress bar. Will be in the stdout when debug mode is turned on
+    """
     _args = ConfigArguments.get_instance()
     bar_len = 60
     filled_len = int(round(bar_len * count / float(total)))
     percents = round(100.0 * count / float(total), 1)
-    bar = '=' * filled_len + '-' * (bar_len - filled_len)
-    if _args.debug:
+    bar = '=' * filled_len + ">"+'-' * (bar_len - filled_len)
+    if get_rank()==0:
         if count == 1:
             print("")
-        print("\r[{}] {}% {} of {} {} ".format(bar, percents, count, total, status), end='')
+        print("\r{}: [{}] {}% {} of {} ".format(status, bar, percents, count, total), end='')
         if count == total:
             print("")
         os.sys.stdout.flush()

--- a/src/utils/utility.py
+++ b/src/utils/utility.py
@@ -18,9 +18,17 @@ import os
 from datetime import datetime
 
 from src.utils.config import ConfigArguments
-
+from time import time
 # UTC timestamp format with microsecond precision
 LOG_TS_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
+
+def timeit(func):
+    def wrapper(*args, **kwargs):
+        begin = time()
+        x = func(*args, **kwargs)
+        end = time()
+        return x, "%10.10f"%begin, "%10.10f"%end, os.getpid()
+    return wrapper
 
 # Where does this print? I don't see it in the terminal
 def progress(count, total, status=''):

--- a/src/utils/utility.py
+++ b/src/utils/utility.py
@@ -1,5 +1,6 @@
 """
-   Copyright 2021 UChicago Argonne, LLC
+   Copyright (c) 2022, UChicago Argonne, LLC
+   All Rights Reserved
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/utils/utility.py
+++ b/src/utils/utility.py
@@ -19,9 +19,13 @@ from datetime import datetime
 
 from src.utils.config import ConfigArguments
 from time import time
+from functools import wraps
 # UTC timestamp format with microsecond precision
 LOG_TS_FORMAT = "%Y-%m-%dT%H:%M:%S.%f"
 from mpi4py import MPI
+
+def utcnow(format=LOG_TS_FORMAT):
+    return datetime.now().strftime(format)
 
 def get_rank():
     return MPI.COMM_WORLD.rank
@@ -30,12 +34,38 @@ def get_size():
     return MPI.COMM_WORLD.size
 
 def timeit(func):
+    @wraps(func)
     def wrapper(*args, **kwargs):
         begin = time()
         x = func(*args, **kwargs)
         end = time()
         return x, "%10.10f"%begin, "%10.10f"%end, os.getpid()
     return wrapper
+
+
+import tracemalloc
+from time import perf_counter 
+
+
+def measure_performance(func):
+    '''Measure performance of a function'''
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        tracemalloc.start()
+        start_time = perf_counter()
+        func(*args, **kwargs)
+        current, peak = tracemalloc.get_traced_memory()
+        finish_time = perf_counter()
+        if get_rank()==0:
+            print(f'[PERFORMANCE] {"="*60}')
+            print(f'[PERFORMANCE] Memory usage:\t\t {current / 10**6:.6f} MB \n'
+                f'[PERFORMANCE] Peak memory usage:\t {peak / 10**6:.6f} MB ')
+            print(f'[PERFORMANCE] Time elapsed:\t\t {finish_time - start_time:.6f} s')
+            print(f'[PERFORMANCE] {"-"*40}')
+        tracemalloc.stop()
+    return wrapper
+
 
 def progress(count, total, status=''):
     """
@@ -47,15 +77,12 @@ def progress(count, total, status=''):
     percents = round(100.0 * count / float(total), 1)
     bar = '=' * filled_len + ">"+'-' * (bar_len - filled_len)
     if get_rank()==0:
-        if count == 1:
-            print("")
-        print("\r{}: [{}] {}% {} of {} ".format(status, bar, percents, count, total), end='')
+        print("\r[INFO] {} {}: [{}] {}% {} of {} ".format(utcnow(), status, bar, percents, count, total), end='')
         if count == total:
             print("")
         os.sys.stdout.flush()
 
-def utcnow(format=LOG_TS_FORMAT):
-    return datetime.now().strftime(format)
+
 
 def str2bool(v):
     if isinstance(v, bool):

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -175,7 +175,7 @@ class TestDLIOBenchmark(unittest.TestCase):
     def test_multi_threads(self) -> None:
         self.clean()
         for framework in "tensorflow", "pytorch":
-            for nt in 0, 1, 2, 4:
+            for nt in 0, 1, 2:
                 if (comm.rank==0):
                     print()
                     print("="*80)

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -1,3 +1,20 @@
+"""
+   Copyright (c) 2022, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
 #!/usr/bin/env python
 from collections import namedtuple
 from src.utils.utility import timeit

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -80,7 +80,6 @@ class TestDLIOBenchmark(unittest.TestCase):
                         self.assertEqual(len(glob.glob(cfg.workload.dataset.data_folder + f"train/*/*.{fmt}")), cfg.workload.dataset.num_files_train)
                         self.assertEqual(len(glob.glob(cfg.workload.dataset.data_folder + f"valid/*/*.{fmt}")), cfg.workload.dataset.num_files_eval)
    
-    """ We are experiencing some hanging issue in this test. Will turn off the test for now. 
     def test_iostat_profiling(self) -> None:
         self.clean()
         if (comm.rank==0):
@@ -111,7 +110,6 @@ class TestDLIOBenchmark(unittest.TestCase):
                 with open(benchmark.output_folder+"./.hydra/overrides.yaml", "w") as f:
                     f.write('[]')
                 os.system(f"python src/dlio_postprocessor.py --output-folder={benchmark.output_folder}")
-    """
     def test_checkpoint_epoch(self) -> None:
         self.clean()
         if (comm.rank==0):

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -30,9 +30,16 @@ comm = MPI.COMM_WORLD
 import pytest
 import time
 import subprocess
-
+import logging
 import os
-
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.FileHandler("dlio_benchmark_test.log", mode = "a", encoding='utf-8'),
+        logging.StreamHandler()
+    ],format='[%(levelname)s] %(message)s [%(pathname)s:%(lineno)d]'  # logging's max timestamp resolution is msecs, we will pass in usecs in the message
+)
+ 
 from src.dlio_benchmark import DLIOBenchmark
 import glob
 class TestDLIOBenchmark(unittest.TestCase):
@@ -56,7 +63,7 @@ class TestDLIOBenchmark(unittest.TestCase):
         benchmark.finalize()
         t1=time.time()
         if (comm.rank==0):
-            print("Time for the benchmark: %.10f" %(t1-t0)) 
+            logging.info("Time for the benchmark: %.10f" %(t1-t0)) 
         if (verify):
             self.assertEqual(len(glob.glob(benchmark.output_folder+"./*_load_and_proc_times.json")), benchmark.comm_size)
         return benchmark
@@ -66,10 +73,10 @@ class TestDLIOBenchmark(unittest.TestCase):
             with self.subTest(f"Testing data generator for format: {fmt}", fmt=fmt):
                 self.clean()
                 if (comm.rank==0):
-                    print()
-                    print("="*80)
-                    print(f" DLIO test for generating {fmt} dataset")
-                    print("="*80)
+                    logging.info("")
+                    logging.info("="*80)
+                    logging.info(f" DLIO test for generating {fmt} dataset")
+                    logging.info("="*80)
                 with initialize(version_base=None, config_path="../configs"):
                     cfg = compose(config_name='config', overrides=['++workload.workflow.train=False', \
                                                                    '++workload.workflow.generate_data=True',
@@ -85,10 +92,10 @@ class TestDLIOBenchmark(unittest.TestCase):
     def test_iostat_profiling(self) -> None:
         self.clean()
         if (comm.rank==0):
-            print()
-            print("="*80)
-            print(f" DLIO test for iostat profiling")
-            print("="*80)
+            logging.info("")
+            logging.info("="*80)
+            logging.info(f" DLIO test for iostat profiling")
+            logging.info("="*80)
         with initialize(version_base=None, config_path="../configs"):
             cfg = compose(config_name='config', overrides=['++workload.workflow.train=False',
                                                            '++workload.workflow.generate_data=True'])
@@ -104,7 +111,7 @@ class TestDLIOBenchmark(unittest.TestCase):
             benchmark=self.run_benchmark(cfg)
             assert(os.path.isfile(benchmark.output_folder+"/iostat.json"))
             if (comm.rank==0):
-                print("generating output data")
+                logging.info("generating output data")
                 os.makedirs(benchmark.output_folder+"/.hydra/", exist_ok=True)
                 yl: str = OmegaConf.to_yaml(cfg)
                 with open(benchmark.output_folder+"./.hydra/config.yaml", "w") as f:
@@ -120,10 +127,10 @@ class TestDLIOBenchmark(unittest.TestCase):
     def test_checkpoint_epoch(self) -> None:
         self.clean()
         if (comm.rank==0):
-                print()
-                print("="*80)
-                print(f" DLIO test for checkpointing at the end of epochs")
-                print("="*80)
+                logging.info("")
+                logging.info("="*80)
+                logging.info(f" DLIO test for checkpointing at the end of epochs")
+                logging.info("="*80)
         with initialize(version_base=None, config_path="../configs"):
             cfg = compose(config_name='config',
                           overrides=['++workload.workflow.train=True',\
@@ -143,10 +150,10 @@ class TestDLIOBenchmark(unittest.TestCase):
     def test_checkpoint_step(self) -> None:
         self.clean()        
         if (comm.rank==0):
-            print()
-            print("="*80)
-            print(f" DLIO test for checkpointing at the end of steps")
-            print("="*80)
+            logging.info("")
+            logging.info("="*80)
+            logging.info(f" DLIO test for checkpointing at the end of steps")
+            logging.info("="*80)
         with initialize(version_base=None, config_path="../configs"):
             cfg = compose(config_name='config',
                           overrides=['++workload.workflow.train=True',\
@@ -169,10 +176,10 @@ class TestDLIOBenchmark(unittest.TestCase):
     def test_eval(self) -> None:
         self.clean()
         if (comm.rank==0):
-            print()
-            print("="*80)
-            print(f" DLIO test for evaluation")
-            print("="*80)        
+            logging.info("")
+            logging.info("="*80)
+            logging.info(f" DLIO test for evaluation")
+            logging.info("="*80)        
         with initialize(version_base=None, config_path="../configs"):
             cfg = compose(config_name='config',
                           overrides=['++workload.workflow.train=True',\
@@ -188,10 +195,10 @@ class TestDLIOBenchmark(unittest.TestCase):
         for framework in "tensorflow", "pytorch":
             for nt in 0, 1, 2:
                 if (comm.rank==0):
-                    print()
-                    print("="*80)
-                    print(f" DLIO test for generating multithreading read_threads={nt} {framework} framework")
-                    print("="*80)
+                    logging.info("")
+                    logging.info("="*80)
+                    logging.info(f" DLIO test for generating multithreading read_threads={nt} {framework} framework")
+                    logging.info("="*80)
                 with self.subTest(f"Testing full benchmark for format: {framework}-NT{nt}", nt=nt, framework=framework):
                     with initialize(version_base=None, config_path="../configs"):
                         cfg = compose(config_name='config', overrides=['++workload.workflow.train=True', \
@@ -214,10 +221,10 @@ class TestDLIOBenchmark(unittest.TestCase):
                             continue
                         self.clean()
                         if (comm.rank==0):
-                            print()
-                            print("="*80)
-                            print(f" DLIO training test for {fmt} format in {framework} framework")
-                            print("="*80)                        
+                            logging.info("")
+                            logging.info("="*80)
+                            logging.info(f" DLIO training test for {fmt} format in {framework} framework")
+                            logging.info("="*80)                        
                         with initialize(version_base=None, config_path="../configs"):
                             cfg = compose(config_name='config', overrides=['++workload.workflow.train=True', \
                                                                            '++workload.workflow.generate_data=True',\

--- a/tests/dlio_postprocessor_test.py
+++ b/tests/dlio_postprocessor_test.py
@@ -1,3 +1,20 @@
+"""
+   Copyright (c) 2022, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
 from collections import namedtuple
 import unittest
 


### PR DESCRIPTION
In this PR, I fixed a bunch of minor issues: 

1) changed copy right symbol to (c) in case it causes trouble in some os. 
2) changed "data_reader" to "reader" in YAML config to be consistent with the naming in the code. 
3) set progress bar to stdout for generating the dataset. 
4) added timing decorator for dataset loading. Detailed timing can be done in debug mode. 
5) removed "file_access" parameter. This will be determined automatically through num_files_train and num_samples_per_file
6) removed unit test for "iostat" profiling in tests/dlio_benchmark_test.py. It causes hang when run in MPI. But this test was able to run outside of pytest. Therefore, I removed it for now, and will investigate further why pytest-mpi cause this test to hang. 