### PR TITLE
Add ckpting to UNET3D workload, remove old prefetch param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Benchmark generated data
 data/
 output/
+checkpoints/
 notes/
 stuff/
 *.un~

--- a/configs/workload/unet3d.yaml
+++ b/configs/workload/unet3d.yaml
@@ -6,6 +6,7 @@ workflow:
   generate_data: False
   train: True
   evaluation: True
+  checkpoint: True
 
 dataset: 
   data_folder: ./data/unet3d/
@@ -28,4 +29,10 @@ train:
 
 evaluation: 
   eval_time: 11.572
+  eval_after_epoch: 5
   epochs_between_evals: 2
+
+checkpoint:
+  checkpoint_after_epoch: 5
+  epochs_between_checkpoints: 2
+  model_size: 499153191

--- a/src/reader/hdf5_stimulate.py
+++ b/src/reader/hdf5_stimulate.py
@@ -107,7 +107,7 @@ class HDF5StimulateReader(FormatReader):
                                           seed=self.seed)
             else:
                 dataset = dataset.shuffle(buffer_size=self.shuffle_size)
-        if self.prefetch:
+        if self.prefetch_size > 0:
             dataset = dataset.prefetch(buffer_size=self.prefetch_size)
 
         dataset = dataset.map(self.resize, num_parallel_calls=self.computation_threads)

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -149,8 +149,6 @@ def LoadConfig(args, config):
             args.read_threads = config['data_reader']['read_threads']
         if 'computatation_threads' in config['data_reader']:
             args.computatation_threads = config['data_reader']['computatation_threads']
-        if 'prefetch' in config['data_reader']:
-            args.prefetch = config['data_reader']['prefetch']
         if 'prefetch_size' in config['data_reader']:
             args.prefetch_size = config['data_reader']['prefetch_size']
         if 'read_shuffle' in config['data_reader']:


### PR DESCRIPTION
- Add checkpointing after every eval for UNET3D
- Remove old prefetch param & align hdf5_stimulate (btw, should it be called simulate?) that was the only one still using it
- add checkpoints folder to gitignore