### PR TITLE
Add the UNET3D sleep time for V100 32GB batch size 4

### DIFF
--- a/configs/workload/unet3d.yaml
+++ b/configs/workload/unet3d.yaml
@@ -5,14 +5,12 @@ framework: pytorch
 workflow:
   generate_data: False
   train: True
-  evaluation: True
   checkpoint: True
 
 dataset: 
   data_folder: ./data/unet3d/
   format: npz
   num_files_train: 168
-  num_files_eval: 42
   num_samples_per_file: 1
   record_length: 234560851
   record_length_stdev: 109346892
@@ -20,18 +18,13 @@ dataset:
   
 reader: 
   data_loader: pytorch
-  batch_size: 2
-  batch_size_eval: 1
+  batch_size: 4
   read_threads: 4
 
 train:
   epochs: 10
-  computation_time: 0.753
+  computation_time: 1.3604
 
-evaluation: 
-  eval_time: 5.8
-  epochs_between_evals: 2
-  
 checkpoint:
   checkpoint_after_epoch: 5
   epochs_between_checkpoints: 2

--- a/src/reader/torch_data_loader_reader.py
+++ b/src/reader/torch_data_loader_reader.py
@@ -117,7 +117,7 @@ class TorchDataLoaderReader(FormatReader):
             prefetch_factor = self.prefetch_size
         if prefetch_factor>0:
             if self.my_rank==0:
-                logging.info(f"{utcnow()} Prefetch size is {prefetch_size}; prefetch factor of {prefetch_factor} will be set to Torch DataLoader.")
+                logging.info(f"{utcnow()} Prefetch size is {self.prefetch_size}; prefetch factor of {prefetch_factor} will be set to Torch DataLoader.")
         else:
             if self.my_rank==0:
                 logging.info(f"{utcnow()} Prefetch size is 0; a default prefetch factor of 2 will be set to Torch DataLoader.")


### PR DESCRIPTION
- Added the measured sleep time for V100-32GB batch size 4
- Removed evaluation from the UNET3D config
- fix random bug

PS: Did we say we want the base dataset to be 300GB instead of the current 30GB? 