### PR TITLE
Minor config changes

### DIFF
--- a/configs/workload/bert.yaml
+++ b/configs/workload/bert.yaml
@@ -3,30 +3,33 @@ model: bert
 framework: tensorflow
 
 workflow:
- generate_data: False
- train: True
- debug: False
- checkpoint: True
+  generate_data: False
+  train: True
+  debug: False
+  checkpoint: True
  
 dataset: 
- data_folder: data/bert
- format: tfrecord
- num_files_train: 500
- num_samples_per_file: 313532
- record_length: 2500
-
+  data_folder: data/bert
+  format: tfrecord
+  num_files_train: 500
+  num_samples_per_file: 313532
+  record_length: 2500
+  file_prefix: part
 
 train:
- computation_time: 0.968
- total_training_steps: 5000
+  computation_time: 0.968
+  total_training_steps: 5000
  
 reader:
- data_loader: tensorflow
- read_threads: 1
- computation_threads: 8
- transfer_size: 262144
- batch_size: 48
+  data_loader: tensorflow
+  read_threads: 1
+  computation_threads: 8
+  transfer_size: 262144
+  batch_size: 48
+  file_shuffle: seed
+  sample_shuffle: seed
 
 checkpoint:
- steps_between_checkpoints: 1250
- model_size: 4034713312
+  checkpoint_folder: checkpoints/bert
+  steps_between_checkpoints: 1250
+  model_size: 4034713312

--- a/configs/workload/unet3d.yaml
+++ b/configs/workload/unet3d.yaml
@@ -9,19 +9,20 @@ workflow:
   checkpoint: True
 
 dataset: 
-  data_folder: ./data/unet3d/
+  data_folder: data/unet3d/
   format: npz
   num_files_train: 168
   num_files_eval: 42
   num_samples_per_file: 1
   record_length: 234560851
   record_length_stdev: 109346892
-  keep_files: True
   
 reader: 
   data_loader: pytorch
   batch_size: 2
   batch_size_eval: 1
+  file_shuffle: seed
+  sample_shuffle: seed
 
 train:
   epochs: 10
@@ -32,6 +33,7 @@ evaluation:
   epochs_between_evals: 2
   
 checkpoint:
+  checkpoint_folder: checkpoints/unet3d
   checkpoint_after_epoch: 5
   epochs_between_checkpoints: 2
   model_size: 499153191


### PR DESCRIPTION
Minor config changes are added 

1. Two space indentation is added in `bert.yaml `to be consistent with other workloads
2. `file_prefix` is added to `bert` workload file generation. (Default was `img`)
3. `file_shuffle` and `sample_shuffle` is set to `seed` for both `bert` and `unet3d`
4. `checkpoint_folder` location is added to both `bert` and `unet3d`
5. `keep_files` is removed as it is set to true by default 