### PR TITLE
bug fix to free memory once file is completely read

### DIFF
--- a/src/reader/reader_handler.py
+++ b/src/reader/reader_handler.py
@@ -76,10 +76,10 @@ class FormatReader(ABC):
                 batch = np.array(batch)
                 yield is_last, batch
                 batch = []
-        for filename, sample_index in self._args.file_map:
-            if filename in self.open_file_map:
+            if image_processed % self.num_samples_per_file == 0:
                 self.close(filename)
                 self.open_file_map[filename] = None
+
 
     @abstractmethod
     def read_index(self, index):

--- a/src/reader/reader_handler.py
+++ b/src/reader/reader_handler.py
@@ -76,7 +76,7 @@ class FormatReader(ABC):
                 batch = np.array(batch)
                 yield is_last, batch
                 batch = []
-            if image_processed % self.num_samples_per_file == 0:
+            if image_processed % self._args.num_samples_per_file == 0:
                 self.close(filename)
                 self.open_file_map[filename] = None
 


### PR DESCRIPTION
Fixed #50 

The samples are randomized and the files are randomized. But the file_index assigned to the thread is in order. This allows us to free the files once they are fully read.