### PR TITLE
Added Info logging for profiler and removed unnecessary bracket calls.

### DIFF
--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -184,13 +184,13 @@ class PerfTrace:
             os.remove(instance.log_file)
         spec = importlib.util.find_spec('dlio_profiler_py')
         if spec:
+            logging.info(f"{utcnow()} Using DLIO Profiler")
             instance.logger_type = LoggerType.DLIO_PROFILER
             import dlio_profiler_py as dlio_logger
             instance.logger = dlio_logger
             instance.logger.initialize(instance.log_file, f"{data_dir}", process_id=get_rank())
-            with open(instance.log_file, 'w') as f:
-                f.write("[")
         else:
+            logging.info(f"{utcnow()} Using Internal Profiler.")
             instance.logger = logging.getLogger("perftrace")
             instance.logger.setLevel(logging.DEBUG)
             instance.logger.propagate = False
@@ -219,8 +219,6 @@ class PerfTrace:
     def finalize(self):
         if self.logger_type == LoggerType.DLIO_PROFILER:
             self.logger.finalize()
-            with open(self.log_file, 'a') as f:
-                f.write("]")
         else:
             self.logger.debug("]")
 


### PR DESCRIPTION
We do not need [ or ] calls as DLIO Profiler adds them on finalize.
Additionally, adding info logging to show if DLIO Profiler is used or not.