### PR TITLE
Add new FSSPEC storage type

### DIFF
--- a/dlio_benchmark/common/enumerations.py
+++ b/dlio_benchmark/common/enumerations.py
@@ -24,6 +24,18 @@ class StorageType(Enum):
     LOCAL_FS = 'local_fs'
     PARALLEL_FS = 'parallel_fs'
     S3 = 's3'
+    FSSPEC_FS = 'fsspec_fs'
+
+    def __str__(self):
+        return self.value
+
+class FsspecPlugin(Enum):
+    """
+    Different plugins of fsspec implementations
+    """
+    LOCAL_FS = 'local_fs'
+    S3 = 's3'
+    DAOS_FS = 'daos_fs'
 
     def __str__(self):
         return self.value

--- a/dlio_benchmark/configs/workload/krehm.yaml
+++ b/dlio_benchmark/configs/workload/krehm.yaml
@@ -1,0 +1,45 @@
+model: default
+
+framework: pytorch
+
+storage:
+  storage_type: fsspec_fs
+  fsspec_plugin: local_fs
+  fsspec_extra_params:
+    param1: abc
+    param2: def
+    param3: ghi
+
+workflow:
+  generate_data: False
+  train: True
+  evaluation: True
+  profiling: False
+
+dataset: 
+  data_folder: data/default
+  format: npz
+  num_files_train: 64
+  num_files_eval: 8
+  num_samples_per_file: 1
+  record_length: 4096
+  num_subfolders_train: 2
+  num_subfolders_eval: 2
+  
+reader: 
+  data_loader: pytorch
+  batch_size: 4
+  batch_size_eval: 1
+
+train:
+  epochs: 10
+  computation_time: 1.00
+
+
+evaluation: 
+  eval_time: 0.5
+  epochs_between_evals: 1
+
+profiling: 
+  profiler: iostat
+  

--- a/dlio_benchmark/data_generator/data_generator.py
+++ b/dlio_benchmark/data_generator/data_generator.py
@@ -49,8 +49,10 @@ class DataGenerator(ABC):
         self.num_subfolders_train = self._args.num_subfolders_train
         self.num_subfolders_eval = self._args.num_subfolders_eval
         self.format = self._args.format
-        self.storage = StorageFactory().get_storage(self._args.storage_type, self._args.storage_root,
-                                                                        self._args.framework)
+        self.storage = StorageFactory().get_storage(self._args.storage_type,
+                                self._args.storage_root, self._args.framework,
+                                self._args.fsspec_plugin,
+                                self._args.fsspec_extra_params)
     def get_dimension(self):
         if (self._dimension_stdev>0):
             dim1, dim2 = [max(int(d), 1) for d in np.random.normal(self._dimension, self._dimension_stdev, 2)]

--- a/dlio_benchmark/data_generator/hdf5_generator.py
+++ b/dlio_benchmark/data_generator/hdf5_generator.py
@@ -15,6 +15,7 @@
    limitations under the License.
 """
 
+import fsspec
 import h5py
 import numpy as np
 
@@ -50,29 +51,29 @@ class HDF5Generator(DataGenerator):
             dim1, dim2 = self.get_dimension()
             records = np.random.randint(255, size=(samples_per_iter, dim1, dim2), dtype=np.uint8)
             out_path_spec = self.storage.get_uri(self._file_list[i])
-            hf = h5py.File(out_path_spec, 'w')
-            chunks = None
-            if self.enable_chunking:
-                chunk_dimension = int(math.ceil(math.sqrt(self.chunk_size)))
-                if chunk_dimension > self._dimension:
-                    chunk_dimension = self._dimension
-                chunks = (1, chunk_dimension, chunk_dimension)
-            compression = None
-            compression_level = None
-            if self.compression != Compression.NONE:
-                compression = str(self.compression)
-                if self.compression == Compression.GZIP:
-                    compression_level = self.compression_level
-            dset = hf.create_dataset('records', (self.num_samples, dim1, dim2), chunks=chunks, compression=compression,
+            # rehm: should non-fsspec filesystem types be allowed?
+            with fsspec.open(out_path_spec, 'w') as hf:
+                chunks = None
+                if self.enable_chunking:
+                    chunk_dimension = int(math.ceil(math.sqrt(self.chunk_size)))
+                    if chunk_dimension > self._dimension:
+                        chunk_dimension = self._dimension
+                    chunks = (1, chunk_dimension, chunk_dimension)
+                compression = None
+                compression_level = None
+                if self.compression != Compression.NONE:
+                    compression = str(self.compression)
+                    if self.compression == Compression.GZIP:
+                        compression_level = self.compression_level
+                dset = hf.create_dataset('records', (self.num_samples, dim1, dim2), chunks=chunks, compression=compression,
                                      compression_opts=compression_level, dtype=np.uint8)
-            samples_written = 0
-            while samples_written < self.num_samples:
-                if samples_per_iter < self.num_samples-samples_written:
-                    samples_to_write = samples_per_iter
-                else:
-                    samples_to_write = self.num_samples-samples_written
-                dset[samples_written:samples_written+samples_to_write] = records[:samples_to_write]
-                samples_written += samples_to_write
-            hf.create_dataset('labels', data=record_labels)
-            hf.close()
+                samples_written = 0
+                while samples_written < self.num_samples:
+                    if samples_per_iter < self.num_samples-samples_written:
+                        samples_to_write = samples_per_iter
+                    else:
+                        samples_to_write = self.num_samples-samples_written
+                    dset[samples_written:samples_written+samples_to_write] = records[:samples_to_write]
+                    samples_written += samples_to_write
+                hf.create_dataset('labels', data=record_labels)
         np.random.seed()

--- a/dlio_benchmark/data_generator/jpeg_generator.py
+++ b/dlio_benchmark/data_generator/jpeg_generator.py
@@ -18,6 +18,7 @@
 from dlio_benchmark.common.enumerations import Compression
 from dlio_benchmark.data_generator.data_generator import DataGenerator
 
+import fsspec
 import logging
 import numpy as np
 
@@ -54,5 +55,7 @@ class JPEGGenerator(DataGenerator):
                 logging.info(f"Generated file {i}/{self.total_files_to_generate}")
             out_path_spec = self.storage.get_uri(self._file_list[i])
             progress(i+1, self.total_files_to_generate, "Generating JPEG Data")
-            img.save(out_path_spec, format='JPEG', bits=8)
+            # rehm: should non-fsspec filesystem types be allowed?
+            with fsspec.open(out_path_spec, 'w') as f:
+                img.save(f, format='JPEG', bits=8)
         np.random.seed()

--- a/dlio_benchmark/data_generator/npz_generator.py
+++ b/dlio_benchmark/data_generator/npz_generator.py
@@ -18,6 +18,7 @@
 from dlio_benchmark.common.enumerations import Compression
 from dlio_benchmark.data_generator.data_generator import DataGenerator
 
+import fsspec
 import logging
 import numpy as np
 
@@ -48,8 +49,10 @@ class NPZGenerator(DataGenerator):
             out_path_spec = self.storage.get_uri(self._file_list[i])
             progress(i+1, self.total_files_to_generate, "Generating NPZ Data")
             prev_out_spec = out_path_spec
-            if self.compression != Compression.ZIP:
-                np.savez(out_path_spec, x=records, y=record_labels)
-            else:
-                np.savez_compressed(out_path_spec, x=records, y=record_labels)
+            # rehm: should non-fsspec filesystem types be allowed?
+            with fsspec.open(out_path_spec, 'w') as f:
+                if self.compression != Compression.ZIP:
+                    np.savez(f, x=records, y=record_labels)
+                else:
+                    np.savez_compressed(f, x=records, y=record_labels)
         np.random.seed()

--- a/dlio_benchmark/data_generator/png_generator.py
+++ b/dlio_benchmark/data_generator/png_generator.py
@@ -18,6 +18,7 @@
 from dlio_benchmark.common.enumerations import Compression
 from dlio_benchmark.data_generator.data_generator import DataGenerator
 
+import fsspec
 import logging
 import numpy as np
 
@@ -51,5 +52,7 @@ class PNGGenerator(DataGenerator):
                 logging.info(f"Generated file {i}/{self.total_files_to_generate}")
             progress(i+1, self.total_files_to_generate, "Generating PNG Data")
             prev_out_spec = out_path_spec
-            img.save(out_path_spec, format='PNG', bits=8)
+            # rehm: should non-fsspec filesystem types be allowed?
+            with fsspec.open(out_path_spec, 'w') as f:
+                img.save(f, format='PNG', bits=8)
         np.random.seed()

--- a/dlio_benchmark/framework/tf_framework.py
+++ b/dlio_benchmark/framework/tf_framework.py
@@ -59,7 +59,10 @@ class TFFramework(Framework):
                                                          dataset_type=DatasetType.TRAIN, epoch=epoch)
         self.reader_valid = DataLoaderFactory.get_loader(data_loader, format_type,
                                                          dataset_type=DatasetType.VALID, epoch=epoch)
-        self.storage = StorageFactory().get_storage(self.args.storage_type, self.args.storage_root, self.args.framework)
+        self.storage = StorageFactory().get_storage(self.args.storage_type,
+                                    self.args.storage_root, self.args.framework,
+                                    self.args.fsspec_plugin,
+                                    self.args.fsspec_extra_params)
 
     @dlp.log
     def get_type(self):

--- a/dlio_benchmark/framework/torch_framework.py
+++ b/dlio_benchmark/framework/torch_framework.py
@@ -69,7 +69,9 @@ class TorchFramework(Framework):
                                                          dataset_type=DatasetType.TRAIN, epoch=epoch)
         self.reader_valid = DataLoaderFactory.get_loader(data_loader, format_type,
                                                          dataset_type=DatasetType.VALID, epoch=epoch)
-        self.storage = StorageFactory().get_storage(self.args.storage_type, self.args.storage_root, self.args.framework)
+        self.storage = StorageFactory().get_storage(self.args.storage_type,
+                                self.args.storage_root, self.args.framework,
+                                self.args.fsspec_plugin, self.args.fsspec_extra_params)
 
     @dlp.log
     def get_type(self):

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -74,7 +74,10 @@ class DLIOBenchmark(object):
         self.output_folder = self.args.output_folder
         PerfTrace.initialize_log(self.args.output_folder, os.path.abspath(self.args.data_folder))
         with Profile(name=f"{self.__init__.__qualname__}", cat=MODULE_DLIO_BENCHMARK):
-            self.storage = StorageFactory().get_storage(self.args.storage_type, self.args.storage_root, self.args.framework)
+            self.storage = StorageFactory().get_storage(self.args.storage_type,
+                                    self.args.storage_root, self.args.framework,
+                                    self.args.fsspec_plugin,
+                                    self.args.fsspec_extra_params)
 
             self.output_folder = self.args.output_folder
             self.logfile = os.path.join(self.output_folder, self.args.log_file)

--- a/dlio_benchmark/storage/fsspec_storage.py
+++ b/dlio_benchmark/storage/fsspec_storage.py
@@ -97,25 +97,21 @@ class FsspecStorage(DataStorage):
     # Namespace APIs
     @dlp.log
     def create_namespace(self, exist_ok=False):
-        pdb.set_trace()
         self.fs.makedirs(self.get_uri(), exist_ok=exist_ok)
         return True
 
     @dlp.log
     def get_namespace(self):
-        pdb.set_trace()
         return self.namespace.name
 
     # Metadata APIs
     @dlp.log
     def create_node(self, id, exist_ok=False):
-        pdb.set_trace()
         self.fs.makedirs(self.get_uri(id), exist_ok=exist_ok)
         return True
 
     @dlp.log
     def get_node(self, id=None):
-        pdb.set_trace()
         path = self.get_uri(id)
         if self.fs.exists(path):
             if self.fs.isdir(path):
@@ -129,28 +125,24 @@ class FsspecStorage(DataStorage):
     def walk_node(self, id, use_pattern=False):
 # rehm: I need to test the NotFoundError logic here that exists for S3 and
 # maybe duplicate it.  Is the exception the same?
-        pdb.set_trace()
         if not use_pattern:
-            return self.fs.listdir(self.get_uri(id))
+            return self.fs.listdir(self.get_uri(id, detail=False))
         else:
             return self.fs.glob(self.get_uri(id))
 
     @dlp.log
     def delete_node(self, id):
-        pdb.set_trace()
         self.fs.rm(self.get_uri(id), recursive=True)
         return True
 
     # TODO Handle partial read and writes
     @dlp.log
     def put_data(self, id, data, offset=None, length=None):
-        pdb.set_trace()
         with self.fs.open(self.get_uri(id), mode="w") as fd:
             fd.write(data)
 
     @dlp.log
     def get_data(self, id, data, offset=None, length=None):
-        pdb.set_trace()
         with self.fs.open(self.get_uri(id), mode="r") as fd:
             data = fd.read()
         return data
@@ -179,5 +171,4 @@ class FsspecStorage(DataStorage):
         return self.fs.open(self.get_uri(id), mode=mode)
     
     def get_basename(self, id):
-        pdb.set_trace()
         return os.path.basename(id)

--- a/dlio_benchmark/storage/fsspec_storage.py
+++ b/dlio_benchmark/storage/fsspec_storage.py
@@ -1,0 +1,183 @@
+"""
+   Copyright (c) 2022, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+from abc import ABC, abstractmethod
+from time import time
+import importlib
+import os
+import pdb
+
+from dlio_benchmark.common.constants import MODULE_STORAGE
+from dlio_benchmark.common.enumerations import FsspecPlugin
+from dlio_benchmark.storage.storage_handler import DataStorage, Namespace
+from dlio_benchmark.common.enumerations import NamespaceType, MetadataType
+from dlio_benchmark.utils.utility import Profile
+
+try:
+    import fsspec
+except ImportError:
+    fsspec = None
+
+dlp = Profile(MODULE_STORAGE)
+
+supported_fsspec_plugins = {
+    FsspecPlugin.LOCAL_FS: {
+                'type': NamespaceType.HIERARCHICAL,
+                'plugin_name': 'file',
+                'prefix': 'file://',
+                'external_module': None
+             }
+}
+
+class FsspecStorage(DataStorage):
+    """
+    Storage API for creating local filesystem files.
+    """
+
+# Different plugins will have different NamespaceType values.  Maybe we define
+# a list at the top here of the plugins we support.  For each of them we define
+# the prefix to use, e.g. "s3fs://".  For each of them there is also a list
+# of the pip3 module that must be installed, which we test for and complain
+# if missing.  We separately test for fsspec itself first.
+#
+# rehm: for daos, namespace will be <pool>:<cont>
+
+    @dlp.log_init
+    def __init__(self, namespace, fsspec_plugin, fsspec_extra_params):
+        if fsspec is None:
+            raise ModuleNotFoundError(
+                "Package 'fsspec' must be installed in order to use fsspec-based storage types"
+            )
+
+        if not fsspec_plugin in supported_fsspec_plugins:
+            raise Exception(
+                "Unsupported fsspec plugin name '{0}' specified".format(fsspec_plugin)
+            )
+
+        plugin = supported_fsspec_plugins[fsspec_plugin]
+        if plugin['external_module'] is not None:
+            try:
+                importlib.import_module(plugin['external_module'])
+            except ImportError:
+                raise ModuleNotFoundError(
+                    "Package '{0}' must be installed in order to use fsspec plugin {1}".format(plugin['external_module'], fsspec_plugin)
+                )
+
+        self.fsspec_plugin = fsspec_plugin
+        self.prefix = plugin['prefix']
+        self.fs = fsspec.filesystem(plugin['plugin_name'])
+# rehm: the namespace here must start with a / and must not end with a /.
+# No, not true.  Do we check anything at all?  What about S3, doesn't a trailing
+# slash mean something different?
+        self.namespace = Namespace(namespace, plugin['type'])
+
+    @dlp.log
+    def get_uri(self, id=None):
+        if id is None:
+            return self.prefix + self.namespace.name
+        else:
+            return self.prefix + os.path.join(self.namespace.name, id)
+
+# rehm: see https://snyk.io/advisor/python/fsspec/functions/fsspec.filesystem
+# for the complexities of providing all the possible credentials.
+
+    # Namespace APIs
+    @dlp.log
+    def create_namespace(self, exist_ok=False):
+        pdb.set_trace()
+        self.fs.makedirs(self.get_uri(), exist_ok=exist_ok)
+        return True
+
+    @dlp.log
+    def get_namespace(self):
+        pdb.set_trace()
+        return self.namespace.name
+
+    # Metadata APIs
+    @dlp.log
+    def create_node(self, id, exist_ok=False):
+        pdb.set_trace()
+        self.fs.makedirs(self.get_uri(id), exist_ok=exist_ok)
+        return True
+
+    @dlp.log
+    def get_node(self, id=None):
+        pdb.set_trace()
+        path = self.get_uri(id)
+        if self.fs.exists(path):
+            if self.fs.isdir(path):
+                return MetadataType.DIRECTORY
+            else:
+                return MetadataType.FILE
+        else:
+            return None
+
+    @dlp.log
+    def walk_node(self, id, use_pattern=False):
+# rehm: I need to test the NotFoundError logic here that exists for S3 and
+# maybe duplicate it.  Is the exception the same?
+        pdb.set_trace()
+        if not use_pattern:
+            return self.fs.listdir(self.get_uri(id))
+        else:
+            return self.fs.glob(self.get_uri(id))
+
+    @dlp.log
+    def delete_node(self, id):
+        pdb.set_trace()
+        self.fs.rm(self.get_uri(id), recursive=True)
+        return True
+
+    # TODO Handle partial read and writes
+    @dlp.log
+    def put_data(self, id, data, offset=None, length=None):
+        pdb.set_trace()
+        with self.fs.open(self.get_uri(id), mode="w") as fd:
+            fd.write(data)
+
+    @dlp.log
+    def get_data(self, id, data, offset=None, length=None):
+        pdb.set_trace()
+        with self.fs.open(self.get_uri(id), mode="r") as fd:
+            data = fd.read()
+        return data
+
+# rehm: get_flo() returns returns a file-like object that can be used in a
+# with block.  Will this work as a parameeter to PIL.Image() and np()?  Does
+# the FLO get cleaned up when it goes out of scope in the caller, the caller
+# needs no close() function?  No, see:
+#    https://filesystem-spec.readthedocs.io/en/latest/api.html
+# at fsspec.core.OpenFile() which says that the caller must explicitly call
+# close() when done to release the file descriptor.
+# No, bigger problem, the caller won't have fsspec imported, can he call
+# flo.close() then?
+# What would happen if I returned flo.open() to the caller?  I can't call 
+# flo.close() as that would affect the caller.  The flo will be lost after the
+# return.  Maybe save in a dict, the fd points to the flo, and then provide
+# a close() function with passes the fd?
+# "as the low-level file object is not created until invoked with 'with'".
+# Assuming it works, then partial read and write, seek, truncate, etc  will
+# also work.
+# Investigate adding compression and buffering options.
+
+    @dlp.log
+    def get_flo(self, id, mode="r"):
+        pdb.set_trace()
+        return self.fs.open(self.get_uri(id), mode=mode)
+    
+    def get_basename(self, id):
+        pdb.set_trace()
+        return os.path.basename(id)

--- a/dlio_benchmark/storage/storage_factory.py
+++ b/dlio_benchmark/storage/storage_factory.py
@@ -16,6 +16,7 @@
 """
 from dlio_benchmark.storage.file_storage import FileStorage
 from dlio_benchmark.storage.s3_storage import S3Storage
+from dlio_benchmark.storage.fsspec_storage import FsspecStorage
 from dlio_benchmark.common.enumerations import StorageType
 from dlio_benchmark.common.error_code import ErrorCodes
 
@@ -23,11 +24,12 @@ class StorageFactory(object):
     def __init__(self):
         pass
 
-    @staticmethod
-    def get_storage(storage_type, namespace, framework=None):
+    def get_storage(self, storage_type, namespace, framework, fsspec_plugin, fsspec_extra_params):
         if storage_type == StorageType.LOCAL_FS:
             return FileStorage(namespace, framework)
         elif storage_type == StorageType.S3:
             return S3Storage(namespace, framework)
+        elif storage_type == StorageType.FSSPEC_FS:
+            return FsspecStorage(namespace, fsspec_plugin, fsspec_extra_params)
         else:
             raise Exception(str(ErrorCodes.EC1001))

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -24,7 +24,7 @@ from time import time
 from typing import List, ClassVar
 
 from dlio_benchmark.common.constants import MODULE_CONFIG
-from dlio_benchmark.common.enumerations import StorageType, FormatType, Shuffle, ReadType, FileAccess, Compression, \
+from dlio_benchmark.common.enumerations import StorageType, FsspecPlugin, FormatType, Shuffle, ReadType, FileAccess, Compression, \
     FrameworkType, \
     DataLoaderType, Profiler, DatasetType, DataLoaderSampler
 from dataclasses import dataclass
@@ -53,6 +53,9 @@ class ConfigArguments:
     # Set root as the current directory by default
     storage_root: str = "./"
     storage_type: StorageType = StorageType.LOCAL_FS
+    # fsspec options ignored if storage_type != StorageType.FSSPEC_FS
+    fsspec_plugin: FsspecPlugin = FsspecPlugin.LOCAL_FS
+    fsspec_extra_params = {}
     record_length: int = 64 * 1024
     record_length_stdev: int = 0
     record_length_resize: int = 0
@@ -307,6 +310,10 @@ def LoadConfig(args, config):
             args.storage_type = StorageType(config['storage']['storage_type'])
         if 'storage_root' in config['storage']:
             args.storage_root = config['storage']['storage_root']
+        if 'fsspec_plugin' in config['storage']:
+            args.fsspec_plugin = FsspecPlugin(config['storage']['fsspec_plugin'])
+        if 'fsspec_extra_params' in config['storage']:
+            args.fsspec_extra_params = config['storage']['fsspec_extra_params']
         
     # dataset related settings
     if 'dataset' in config:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ cachetools==5.2.0
 certifi==2022.9.24
 charset-normalizer==2.1.1
 flatbuffers==22.10.26
+fsspec=2023.10.0
 gast==0.4.0
 google-auth==2.14.1
 google-auth-oauthlib==0.4.6


### PR DESCRIPTION
Add a new FSSPEC storage type implemented using the fsspec filesystem specification.  This is in preparation for adding a new DAOS fsspec plugin so that dlio_benchmark can be used directly with the DAOS DFS library. fsspec also makes it possible to use S3 with both TF and PyTorch.  Other fsspec filesystem emulations like hdf5 are also possible.