### PR TITLE
Switch dlio_profiler to use pypi instead of github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ core_deps = [
  'h5py',
  'pandas',
  'psutil',
- 'dlio_profiler_py @ git+https://github.com/hariharan-devarajan/dlio-profiler.git@v0.0.2'
+ 'dlio_profiler_py==0.0.2'
 ]
 x86_deps = [
  'hydra-core == 1.2.0',


### PR DESCRIPTION
PyPI now hosts the source of dip_profiler_py at https://files.pythonhosted.org/packages/ac/b0/6ed842fd785ce692268b92461e6348b39fe9dca5d9ebea725d7d54edfa3b/dlio_profiler_py-0.0.2.tar.gz and can be directly used instead of the GitHub link. GitHub link would be only needed if we need the dev version of dlio_profiler