### PR TITLE
Reopen dlio.log in non-fork reader_threads child processes

### DIFF
--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -54,6 +54,8 @@ class TorchDataset(Dataset):
     @dlp.log
     def worker_init(self, worker_id):
         pickle.loads(self.serial_args)
+        _args = ConfigArguments.get_instance()
+        _args.configure_dlio_logging(True)
         logging.debug(f"{utcnow()} worker initialized {worker_id} with format {self.format_type}")
         self.reader = ReaderFactory.get_reader(type=self.format_type,
                                                dataset_type=self.dataset_type,


### PR DESCRIPTION
When reader_threads child processes are started with multiprocessing_context set to either spawn or forkserver, the new child processes do not have the dlio.log file open any longer.  Change worker_init() to reopen the dlio.log file in those cases. When the context is set to fork, the dlio.log file remains open in the child process and does not have to be reopened.