### PR TITLE
Fixed printing for DLIO output.

### DIFF
--- a/dlio_benchmark/data_loader/data_loader_factory.py
+++ b/dlio_benchmark/data_loader/data_loader_factory.py
@@ -17,7 +17,7 @@
 import logging
 from dlio_benchmark.utils.config import ConfigArguments
 
-from dlio_benchmark.utils.utility import utcnow
+from dlio_benchmark.utils.utility import utcnow, DLIOMPI
 
 from dlio_benchmark.common.enumerations import DataLoaderType
 from dlio_benchmark.common.error_code import ErrorCodes
@@ -34,7 +34,8 @@ class DataLoaderFactory(object):
         """
         _args = ConfigArguments.get_instance()
         if _args.data_loader_class is not None:
-            logging.info(f"{utcnow()} Running DLIO with custom data loader class {_args.data_loader_class.__name__}")
+            if DLIOMPI.get_instance().rank() == 0:
+                logging.info(f"{utcnow()} Running DLIO with custom data loader class {_args.data_loader_class.__name__}")
             return _args.data_loader_class(format_type, dataset_type, epoch)
         elif type == DataLoaderType.PYTORCH:
             from dlio_benchmark.data_loader.torch_data_loader import TorchDataLoader
@@ -49,5 +50,6 @@ class DataLoaderFactory(object):
             from dlio_benchmark.data_loader.native_dali_data_loader import NativeDaliDataLoader
             return NativeDaliDataLoader(format_type, dataset_type, epoch)
         else:
-            print("Data Loader %s not supported or plugins not found" % type)
-            raise Exception(str(ErrorCodes.EC1004))
+            if DLIOMPI.get_instance().rank() == 0:
+                print("Data Loader %s not supported or plugins not found" % type)
+                raise Exception(str(ErrorCodes.EC1004))

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -91,7 +91,7 @@ class DLIOBenchmark(object):
         self.comm.barrier()
         # Configure the logging library
         self.args.configure_dlio_logging(is_child=False)
-        self.dlp_logger = self.args.configure_dlio_profiler(is_child=False, use_pid=False)
+        self.dlio_profiler = self.args.configure_dlio_profiler(is_child=False, use_pid=False)
         with Profile(name=f"{self.__init__.__qualname__}", cat=MODULE_DLIO_BENCHMARK):
             if self.args.my_rank == 0:
                 logging.info(f"{utcnow()} Running DLIO with {self.args.comm_size} process(es)")
@@ -375,7 +375,7 @@ class DLIOBenchmark(object):
             self.stats.finalize()
             self.stats.save_data()
         self.comm.barrier()
-        self.dlp_logger.finalize()
+        self.args.finalize_dlio_profiler(self.dlio_profiler)
 
 
 @hydra.main(version_base=None, config_path="configs", config_name="config")

--- a/dlio_benchmark/reader/reader_factory.py
+++ b/dlio_benchmark/reader/reader_factory.py
@@ -15,7 +15,7 @@
    limitations under the License.
 """
 import logging
-from dlio_benchmark.utils.utility import utcnow
+from dlio_benchmark.utils.utility import utcnow, DLIOMPI
 
 from dlio_benchmark.utils.config import ConfigArguments
 
@@ -35,7 +35,8 @@ class ReaderFactory(object):
 
         _args = ConfigArguments.get_instance()
         if _args.reader_class is not None:
-            logging.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
+            if DLIOMPI.get_instance().rank() == 0:
+                logging.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
             return _args.reader_class(dataset_type, thread_index, epoch_number)
         elif type == FormatType.HDF5:
             from dlio_benchmark.reader.hdf5_reader import HDF5Reader


### PR DESCRIPTION
Currently, we print the dlp logger file even if DLIO is disabled. Also, we need to print only for rank 0—similar changes for all factories.