### PR TITLE
Doc changes to fix DLIO profiler and remove IOStat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,6 @@ pip install .
 dlio_benchmark ++workload.workflow.generate_data=True
 ```
 
-### Bare metal installation with profiler
-
-```bash
-git clone https://github.com/argonne-lcf/dlio_benchmark
-cd dlio_benchmark/
-pip install .[dlio_profiler]
-```
 ## Container
 
 ```bash
@@ -38,6 +31,7 @@ You can also pull rebuilt container from docker hub (might not reflect the most 
 docker docker.io/zhenghh04/dlio:latest
 docker run -t docker.io/zhenghh04/dlio:latest python ./dlio_benchmark/main.py ++workload.workflow.generate_data=True
 ```
+If your running on a different architecture, refer to the Dockerfile to build the dlio_benchmark container from scratch.
 
 One can also run interactively inside the container
 ```bash
@@ -86,7 +80,7 @@ Finally, run the benchmark
   ```
 Finally, run the benchmark with Profiler
   ```bash
-  export ENV DLIO_PROFILER_ENABLE=1
+  export DLIO_PROFILER_ENABLE=1
   export DLIO_PROFILER_INC_METADATA=1
   mpirun -np 8 dlio_benchmark workload=unet3d
   ```

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -351,25 +351,16 @@ profiling
    * - Parameter
      - Default
      - Description
-   * - profiler
-     - none
-     - specifying the profiler to use [none|iostat|tensorflow|pytorch]
    * - iostat_devices**
      - [sda, sdb]
      - specifying the devices to perform iostat tracing.  
 
 .. note::
    
-   We support following I/O profiling using following profilers: 
+   We support multi-level profiling using:
+    * ``dlio_profiler``: https://github.com/hariharan-devarajan/dlio-profiler. DLIO_PROFILER_ENABLE=1 has to be set to enable profiler.
 
-    * ``darshan``: https://www.mcs.anl.gov/research/projects/darshan/. ``LD_PRELOAD`` has to be set for the darshan runtime library (libdarshan.so) to be loaded properly. 
-
-    * ``iostat``: https://linux.die.net/man/1/iostat. One can specify the command to use for profiling in order to get the profiling for specific disk.   
-    * ``tensorflow`` (tf.profiler): https://www.tensorflow.org/api_docs/python/tf/profiler. This works only for tensorflow framework (and data loader)
-
-    * ``pytorch`` (torch.profiler): https://pytorch.org/docs/stable/profiler.html. This works only for pytorch framework (and data loader).
-
-The YAML files are stored in the `workload`_ folder. 
+The YAML files are stored in the `workload`_ folder.
 It then can be loaded by ```dlio_benchmark``` through hydra (https://hydra.cc/). This will override the default settings. One can override the configurations through command line (https://hydra.cc/docs/advanced/override_grammar/basic/).
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,7 @@ Deep Learning I/O (`DLIO`) Benchmark is a benchmark suite aiming at emulating th
 The main features of `DLIO` include: 
    * Easy-to-use configuration through YAML files which represent the I/O behavior of different deep learing applications.
    * Easy-to-use data generator capable to generate synthetic datasets of different formats, different data organizations and layouts. 
-   * Full transparency over emulation of I/O access with logging and profiling at different levels with modern profilers such as Tensorboard, Torch profiler, darshan and iostat, etc. 
+   * Full transparency over emulation of I/O access with logging and profiling at different levels with DLIO profiler.
    * Supporting emulating both sequential training and distributed data parallel training. 
 
 GitHub repo: https://github.com/argonne-lcf/dlio_benchmark. 

--- a/docs/source/instructions_lassen.rst
+++ b/docs/source/instructions_lassen.rst
@@ -112,20 +112,12 @@ Running the Benchmark
 
 	jsrun --bind packed:4 --smpiargs="-gpu" --nrs 1 --rs_per_host 1 --tasks_per_rs 4 --launch_distribution packed --cpu_per_rs ALL_CPUS --gpu_per_rs ALL_GPUS dlio_benchmark workload=resnet50 ++workload.workflow.generate_data=False ++workload.workflow.train=True
 
-If you want to use a profiler: Same example with using iostat profiler, isting the io devices you would like to trace:
+If you want to use a profiler: Same example with using DLIO Profiler, isting the io devices you would like to trace:
 
 .. code-block:: bash
 
-	jsrun --bind packed:4 --smpiargs="-gpu" --nrs 1 --rs_per_host 1 --tasks_per_rs 4 --launch_distribution packed --cpu_per_rs ALL_CPUS --gpu_per_rs ALL_GPUS dlio_benchmark workload=resnet50 ++workload.workflow.generate_data=False ++workload.workflow.profiling=True ++workload.profiling.profiler=iostat ++workload.profiling.iostat_devices=[sda,sdb]
+    export DLIO_PROFILER_ENABLE=1
+	jsrun --bind packed:4 --smpiargs="-gpu" --nrs 1 --rs_per_host 1 --tasks_per_rs 4 --launch_distribution packed --cpu_per_rs ALL_CPUS --gpu_per_rs ALL_GPUS dlio_benchmark workload=resnet50 ++workload.workflow.generate_data=False ++workload.workflow.profiling=True
 
 All the outputs will be stored in ```hydra_log/WORKLOAD/$DATE-$TIME``` folder, where WORKLOAD could be `cosmoflow` etc or in our examples resnet50 if you are using the existing workloads. If you are using a custom workload this will be in the absolute path that you specified in your .yaml file.
 
-''''''''''''''''''''''''
-To post process the data
-''''''''''''''''''''''''
-
-.. code-block:: bash
-
-	dlio_postprocessor --output-folder hydra_log/WORKLOAD/$DATE-$TIME
-
-This will generate ```DLIO_$model_report.txt``` in the output folder, where WORKLOAD could be cosmoflow etc or in our examples `resnet50`.

--- a/docs/source/run.rst
+++ b/docs/source/run.rst
@@ -68,7 +68,7 @@ Profiling
 Application Profiling
 '''''''''''''''''''''
 
-DLIO_Benchmark has an application level profiler by default. The profiler outputs all application level python function calls in <OUTPUT_FOLDER>/.trace*.pfw files.
+DLIO_Benchmark has an application level profiler by default. The profiler outputs all application level python function calls in <OUTPUT_FOLDER>/trace*.pfw files.
 These files are in chrome tracing's json line format. This can be visualized using `perfetto UI https://ui.perfetto.dev/`_
 
 
@@ -87,14 +87,14 @@ Installing just dlio-profiler
     pip install git+https://github.com/hariharan-devarajan/dlio-profiler.git@dev
 
 
-Installing just dlio-profiler along with dlio_benchmark
+DLIO Profiler is always installed along with dlio_benchmark
 
 .. code-block:: bash
 
     cd <DLIO_BENCHMARK_SRC>
-    pip install .[dlio_profiler]
+    pip install .
 
-The profiler outputs all profiling output in <OUTPUT_FOLDER>/.trace*.pfw files.
+The profiler outputs all profiling output in <OUTPUT_FOLDER>/trace*.pfw files.
 It contains application level profiling as well as low-level I/O calls from POSIX and STDIO layers.
 The low-level I/O events are only way to understand I/O pattern from internal framework functions such as TFRecordDataset or DaliDataLoader.
 These files are in chrome tracing's json line format. This can be visualized using `perfetto UI https://ui.perfetto.dev/`_


### PR DESCRIPTION
People get confused with profiler conf as most of it doesn't work. 

Doc fixes include

- [x] Use only DLIO profiler
- [x] Fix trace files and install instructions for DLIO profiler.
- [x] Remove profiler configuration for now.