### PR TITLE
Fix sample shuffling 

### DIFF
--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -467,7 +467,7 @@ def LoadConfig(args, config):
         if 'shuffle_size' in reader:
             args.shuffle_size = reader['shuffle_size']
         if 'sample_shuffle' in reader:
-            args.sample_shuffle = reader['sample_shuffle']
+            args.sample_shuffle = Shuffle(reader['sample_shuffle'])
         if 'read_type' in reader:
             args.read_type = reader['read_type']
         if 'transfer_size' in reader:


### PR DESCRIPTION
So we were not converting the string into enum, causing the issues and confusion for #149.

Additionally, the random sampler doesn't shard the data. Therefore, I wrote a custom sampler that will shard the dataset and ensure non-overlapping ranges for seeded randomness.
