### PR TITLE
generating indexed_binary files causes kernel OOM to kill process (#181)

### DIFF
--- a/dlio_benchmark/data_generator/indexed_binary_generator.py
+++ b/dlio_benchmark/data_generator/indexed_binary_generator.py
@@ -125,6 +125,7 @@ class IndexedBinaryGenerator(DataGenerator):
                     myfmt = 'B' * data_to_write
                     binary_data = struct.pack(myfmt, *records[:data_to_write])
                     data_file.write(binary_data)
+                    struct._clearcache()
 
                     # Write offsets
                     myfmt = 'Q' * samples_to_write


### PR DESCRIPTION
The struct.pack() call in generate() in indexed_binary_generator.py caches the data that it produces, and apparently doesn't evict the cache, such that after 49 indexed_binary files have been created the kernel kills the process due to OOM.  This mod adds a call to struct._clearcache() after each data files is written to release the cached data, keeping the process memory size stable.