### PR TITLE
Improve tfreader parsing performance (batch)

### DIFF
--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -86,21 +86,19 @@ class TFReader(FormatReader):
         self._dataset = tf.data.TFRecordDataset(filenames=self._file_list, buffer_size=self._args.transfer_size, 
                                                 num_parallel_reads=self._args.read_threads)
 
-        self._dataset = self._dataset.batch(self.batch_size)
-        self._dataset = self._dataset.map(
-                lambda x: tf.py_function(func=self._parse_image, inp=[x], Tout=[tf.uint8]), 
-                num_parallel_calls=self._args.computation_threads)
-        self._dataset = self._dataset.unbatch()
-
-        self._dataset = self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
-
         if self._args.sample_shuffle != Shuffle.OFF:
             if self._args.sample_shuffle == Shuffle.SEED:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size,
                                           seed=self._args.seed)
             else:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size)
+
+        self._dataset = self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
         self._dataset = self._dataset.batch(self.batch_size, drop_remainder=True)
+        self._dataset = self._dataset.map(
+                lambda x: tf.py_function(func=self._parse_image, inp=[x], Tout=[tf.uint8]),
+                num_parallel_calls=self._args.computation_threads)
+
         self._dataset = self._dataset.repeat(self._args.epochs)
         total = math.ceil(len(self._file_list)/self._args.comm_size / self.batch_size * self._args.num_samples_per_file)
         return self._dataset.take(total*self._args.epochs).prefetch(buffer_size=self._args.prefetch_size)


### PR DESCRIPTION
Instead of processing the elements one-by-one in the reader pipeline, we use a batch. 

After having applied this modification, perf shows that a couple of functions take less time. 
These function are, I believe , related to C function call switches and python interpreter:
EagerTensor_init took 12% of the time => now 0.26%
pybind11::cpp_function::dispatcher took 10% => now 0.64%
PyEval_EvalFrameDefault took 9% => now 0.19% 


On the same test system, it doubles the throughput of resnet50 (1x H100).
This throughput was also measured on the network:

Test | Throughput (MB/s) | AU (%) | # reader threads
-- | -- | -- | --
Without   patch, 1x H100 | 115.6499 | 59.3728 | 4
With   patch, 1x H100 | 193.4854 | 99.417 | 4



