### PR TITLE
Shard filenames instead of images (tfreader)

### DIFF
--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -83,18 +83,24 @@ class TFReader(FormatReader):
     def next(self):
         logging.debug(
             f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
-        filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
-        filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
-
-        self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
-                                                num_parallel_reads=self._args.read_threads)
+		  filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
+		  # sharding in the file list if we have another files. 
+        if (len(self._file_list) >= self._args.comm_size):
+       	 	filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
+	     self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
+	                                             num_parallel_reads=self._args.read_threads)
+				  
         if self._args.sample_shuffle != Shuffle.OFF:
             if self._args.sample_shuffle == Shuffle.SEED:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size,
                                           seed=self._args.seed)
             else:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size)
-
+		
+		 # shard the dataset if it is not done already.
+		 if (len(self._file_list) < self._args.comm_size):
+			  self._dataset =  self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
+	
         self._dataset = self._dataset.batch(self.batch_size, drop_remainder=True)
         self._dataset = self._dataset.map(
                 lambda x: tf.py_function(func=self._parse_image, inp=[x], Tout=[tf.uint8]),

--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -83,12 +83,13 @@ class TFReader(FormatReader):
     def next(self):
         logging.debug(
             f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
-		  filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
-		  # sharding in the file list if we have another files. 
+		filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
+		# sharding in the file list if we have another files. 
         if (len(self._file_list) >= self._args.comm_size):
-       	 	filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
-	     self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
-	                                             num_parallel_reads=self._args.read_threads)
+			filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
+			
+		self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
+	                                        num_parallel_reads=self._args.read_threads)
 				  
         if self._args.sample_shuffle != Shuffle.OFF:
             if self._args.sample_shuffle == Shuffle.SEED:
@@ -97,9 +98,9 @@ class TFReader(FormatReader):
             else:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size)
 		
-		 # shard the dataset if it is not done already.
-		 if (len(self._file_list) < self._args.comm_size):
-			  self._dataset =  self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
+		# shard the dataset if it is not done already.
+		if (len(self._file_list) < self._args.comm_size):
+			self._dataset =  self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
 	
         self._dataset = self._dataset.batch(self.batch_size, drop_remainder=True)
         self._dataset = self._dataset.map(

--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -83,9 +83,11 @@ class TFReader(FormatReader):
     def next(self):
         logging.debug(
             f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
-        self._dataset = tf.data.TFRecordDataset(filenames=self._file_list, buffer_size=self._args.transfer_size, 
-                                                num_parallel_reads=self._args.read_threads)
+        filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
+        filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
 
+        self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
+                                                num_parallel_reads=self._args.read_threads)
         if self._args.sample_shuffle != Shuffle.OFF:
             if self._args.sample_shuffle == Shuffle.SEED:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size,
@@ -93,7 +95,6 @@ class TFReader(FormatReader):
             else:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size)
 
-        self._dataset = self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
         self._dataset = self._dataset.batch(self.batch_size, drop_remainder=True)
         self._dataset = self._dataset.map(
                 lambda x: tf.py_function(func=self._parse_image, inp=[x], Tout=[tf.uint8]),

--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -83,12 +83,12 @@ class TFReader(FormatReader):
     def next(self):
         logging.debug(
             f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
-		filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
-		# sharding in the file list if we have another files. 
+	filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
+	# sharding in the file list if we have another files. 
         if (len(self._file_list) >= self._args.comm_size):
-			filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
+		filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
 			
-		self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
+	self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
 	                                        num_parallel_reads=self._args.read_threads)
 				  
         if self._args.sample_shuffle != Shuffle.OFF:
@@ -98,9 +98,9 @@ class TFReader(FormatReader):
             else:
                 self._dataset = self._dataset.shuffle(buffer_size=self._args.shuffle_size)
 		
-		# shard the dataset if it is not done already.
-		if (len(self._file_list) < self._args.comm_size):
-			self._dataset =  self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
+	# shard the dataset if it is not done already.
+	if (len(self._file_list) < self._args.comm_size):
+		self._dataset =  self._dataset.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
 	
         self._dataset = self._dataset.batch(self.batch_size, drop_remainder=True)
         self._dataset = self._dataset.map(


### PR DESCRIPTION
Important: This is a draft and I haven't really verified that this change is correct. It could be wrong. 

Instead of sharding the files, we shard the filenames. 

I used the example described in the source code of tensorflow. 
https://github.com/tensorflow/tensorflow/blob/1c7f292617e7c276d03c51894928004625f8ec29/tensorflow/python/data/ops/dataset_ops.py#L1642

```python
    d = Dataset.list_files(pattern, shuffle=False)
    d = d.shard(num_workers, worker_index)
    d = d.repeat(num_epochs)
    d = d.shuffle(shuffle_buffer_size)
    d = d.interleave(tf.data.TFRecordDataset,
                     cycle_length=num_readers, block_length=1)
    d = d.map(parser_fn, num_parallel_calls=num_map_threads)
```

This mean that each MPI process only manage a random set of files, instead of a random set of images from all files.
This change remove the performance bottleneck (~3GB/s).

Test using a RAMDISK as a filesystem with 25 simulated H100 & 4 reader threads for resnet50 (MLPerf).
**Everything is in RAM for this test** 
```sh
./benchmark.sh run --hosts myhost --workload resnet50 --param reader.read_threads=4 --accelerator-type h100 --num-accelerators 25  --results-dir fakeres --param dataset.num_files_train=200 --param dataset.data_folder=/mnt/ramdisk/resnet50
```

result (25 H100)
| DLIO | AU | Throughput (GB/s) |
|----------|----------|----------|
| main    | 51.7146 | 2.475|
| with PR    | 96.5845 | 4.581 |

Above >30 GPU the "with PR" should work (>90% AU) but it hangs before giving the final result. 
I think it is simply due to the fact that I should try with a larger dataset. DLIO profiler is stuck something like this.