### PR TITLE
sync up mlperf_storage_v1.0

### DIFF
--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -36,14 +36,22 @@ from dlio_benchmark.common.enumerations import LoggerType, MPIState
 try:
     from dlio_profiler.logger import dlio_logger as PerfTrace, fn_interceptor as Profile, DLIO_PROFILER_ENABLE
 except:
-    class Profile:
+    class Profile(object):
         def __init__(self, name=None, cat=None):
             self.type = type
         def log(self, func):
             return func
+        def log_init(self, func):
+            return func
         def iter(self, a):
             return a
-    class dlio_logger:
+        def __enter__(self):
+            return
+        def __exit__(self, type, value, traceback):
+            return
+        def update(self, *, epoch=0, step=0, size=0, default=None):
+            return
+    class dlio_logger(object):
         def __init__(self,):
             self.type = None
         def initialize_log(self, logfile=None, data_dir=None, process_id=-1):


### PR DESCRIPTION
* Request changes from MLPerf Storage (#199)

* added au metric to the configuration file; set shuffling and shuffle buffer size to be 2 for cosmoflow

* removed dependencies on dlioprofiler

* fixed bugs

* Fixed potential insufficient samples due to num_files is not divisible by comm.size (#200)

* added au metric to the configuration file; set shuffling and shuffle buffer size to be 2 for cosmoflow

* removed dependencies on dlioprofiler

* fixed bugs

* recovered back dlio_profiler

* fixed potential not enough samples

* Update tf_reader.py

* Mlperf requests (#201)

* added au metric to the configuration file; set shuffling and shuffle buffer size to be 2 for cosmoflow

* removed dependencies on dlioprofiler

* fixed bugs

* fixed issue with dlio_profiler

* bring back dlio_profiler_py