### PR TITLE
Ignore file indexing for native data loader.

### DIFF
--- a/dlio_benchmark/data_loader/tf_data_loader.py
+++ b/dlio_benchmark/data_loader/tf_data_loader.py
@@ -95,7 +95,7 @@ class TFDataLoader(BaseDataLoader):
             self._dataset = ReaderFactory.get_reader(type=self.format_type,
                                           dataset_type=self.dataset_type,
                                           thread_index=-1,
-                                          epoch_number=0).next()
+                                          epoch_number=self.epoch_number).next()
 
     @dlp.log
     def next(self):

--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -81,12 +81,13 @@ class TFReader(FormatReader):
 
     @dlp.log
     def next(self):
-        logging.debug(f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
-        filenames = tf.data.Dataset.list_files(self._file_list, shuffle=True)
+        logging.debug(f"{utcnow()} Reading {self._file_list} files thread {self.thread_index} rank {self._args.my_rank}")
+        filenames = tf.data.Dataset.list_files(self._file_list, shuffle=False)
         # sharding in the file list if we have enought files. 
         if (len(self._file_list) >= self._args.comm_size):
             filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
-			
+            logging.debug(f"{utcnow()} shard {filenames} files index {self._args.my_rank} number {self._args.comm_size}")
+        
         self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
                                                 num_parallel_reads=self._args.read_threads)
 				  

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -371,10 +371,11 @@ class ConfigArguments:
     def reconfigure(self, epoch_number, dataset_type):
         if self.data_loader_sampler == DataLoaderSampler.ITERATIVE:
             if self.file_shuffle is not Shuffle.OFF:
-                if self.seed_change_epoch:
-                    np.random.seed(self.seed + epoch_number)
-                else:
-                    np.random.seed(self.seed)
+                if self.file_shuffle is Shuffle.SEED:
+                    if self.seed_change_epoch:
+                        np.random.seed(self.seed + epoch_number)
+                    else:
+                        np.random.seed(self.seed)
                 np.random.shuffle(self.file_list_train) if dataset_type is DatasetType.TRAIN else np.random.shuffle(
                     self.file_list_eval)
         # the code assumes that file and sample shuffling is handled by the native data loader code.


### PR DESCRIPTION
The sample building and native data loader case is needed only for DLIO created data loaders. For native data loaders which provide their own API;s they provide their own indexing and there this sampling can be ignored.