### PR TITLE
Support for setting different DLIO_LOG_LEVEL

### DIFF
--- a/dlio_benchmark/checkpointing/checkpointing_factory.py
+++ b/dlio_benchmark/checkpointing/checkpointing_factory.py
@@ -31,7 +31,7 @@ class CheckpointingFactory(object):
         _args = ConfigArguments.get_instance()
         if _args.checkpoint_mechanism_class is not None:
             if DLIOMPI.get_instance().rank() == 0:
-                logging.info(f"{utcnow()} Running DLIO with custom checkpointing mechanism "
+                _args.logger.info(f"{utcnow()} Running DLIO with custom checkpointing mechanism "
                              f"class {_args.checkpoint_mechanism_class.__name__}")
             return _args.checkpoint_mechanism_class.get_instance()
         elif checkpoint_mechanism_type == CheckpointMechanismType.TF_SAVE:

--- a/dlio_benchmark/common/enumerations.py
+++ b/dlio_benchmark/common/enumerations.py
@@ -54,9 +54,10 @@ class LogLevel(Enum):
     """
     Different levels of logging
     """
-    DEBUG = "debug"
-    INFO = "info"
+    ERROR = "error" 
     WARN = "warn"
+    INFO = "info"
+    DEBUG = "debug"
     def __str__(self):
         return self.value
 
@@ -115,7 +116,6 @@ class ComputationType(Enum):
     NONE = 'none'
     SYNC = 'sync'
     ASYNC = 'async'
-
 
 class FormatType(Enum):
     """

--- a/dlio_benchmark/common/enumerations.py
+++ b/dlio_benchmark/common/enumerations.py
@@ -54,10 +54,10 @@ class LogLevel(Enum):
     """
     Different levels of logging
     """
-    ERROR = "error" 
-    WARN = "warn"
-    INFO = "info"
     DEBUG = "debug"
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error" 
     def __str__(self):
         return self.value
 

--- a/dlio_benchmark/common/enumerations.py
+++ b/dlio_benchmark/common/enumerations.py
@@ -50,6 +50,15 @@ class StorageType(Enum):
 
     def __str__(self):
         return self.value
+class LogLevel(Enum):
+    """
+    Different levels of logging
+    """
+    DEBUG = "debug"
+    INFO = "info"
+    WARN = "warn"
+    def __str__(self):
+        return self.value
 
 class MetadataType(Enum):
     """

--- a/dlio_benchmark/common/enumerations.py
+++ b/dlio_benchmark/common/enumerations.py
@@ -50,16 +50,6 @@ class StorageType(Enum):
 
     def __str__(self):
         return self.value
-class LogLevel(Enum):
-    """
-    Different levels of logging
-    """
-    DEBUG = "debug"
-    INFO = "info"
-    WARNING = "warning"
-    ERROR = "error" 
-    def __str__(self):
-        return self.value
 
 class MetadataType(Enum):
     """

--- a/dlio_benchmark/data_generator/data_generator.py
+++ b/dlio_benchmark/data_generator/data_generator.py
@@ -48,6 +48,7 @@ class DataGenerator(ABC):
         self.num_subfolders_train = self._args.num_subfolders_train
         self.num_subfolders_eval = self._args.num_subfolders_eval
         self.format = self._args.format
+        self.logger = self._args.logger
         self.storage = StorageFactory().get_storage(self._args.storage_type, self._args.storage_root,
                                                                         self._args.framework)
     def get_dimension(self, num_samples=1):
@@ -74,9 +75,9 @@ class DataGenerator(ABC):
             if self.num_subfolders_eval > 1: 
                 for i in range(self.num_subfolders_eval):
                     self.storage.create_node(self.data_dir + f"/valid/{add_padding(i, nd_sf_eval)}", exist_ok=True)
-            logging.info(f"{utcnow()} Generating dataset in {self.data_dir}/train and {self.data_dir}/valid")
-            logging.info(f"{utcnow()} Number of files for training dataset: {self.num_files_train}")
-            logging.info(f"{utcnow()} Number of files for validation dataset: {self.num_files_eval}")
+            self.logger.info(f"{utcnow()} Generating dataset in {self.data_dir}/train and {self.data_dir}/valid")
+            self.logger.info(f"{utcnow()} Number of files for training dataset: {self.num_files_train}")
+            self.logger.info(f"{utcnow()} Number of files for validation dataset: {self.num_files_eval}")
 
 
         DLIOMPI.get_instance().comm().barrier()

--- a/dlio_benchmark/data_generator/indexed_binary_generator.py
+++ b/dlio_benchmark/data_generator/indexed_binary_generator.py
@@ -54,7 +54,7 @@ class IndexedBinaryGenerator(DataGenerator):
         samples_processed = 0
         total_samples = self.total_files_to_generate * self.num_samples
         dim = self.get_dimension(self.total_files_to_generate)
-        # logging.info(dim)
+        # self.logger.info(dim)
         if self.total_files_to_generate <= self.comm_size:
             # Use collective I/O
             # we need even number os samples for collective I/O
@@ -70,7 +70,7 @@ class IndexedBinaryGenerator(DataGenerator):
                 out_path_spec_sz_idx = self.index_file_path_size(out_path_spec)
                 
                 if self.my_rank == 0:
-                    logging.info(f"{utcnow()} Starting metadata generation. ")
+                    self.logger.info(f"{utcnow()} Starting metadata generation. ")
                 fh_off = MPI.File.Open(comm, out_path_spec_off_idx, amode)
                 fh_sz = MPI.File.Open(comm, out_path_spec_sz_idx, amode)
                 off_type = np.uint64
@@ -90,13 +90,13 @@ class IndexedBinaryGenerator(DataGenerator):
                 fh_off.Close()
                 fh_sz.Close()
                 if self.my_rank == 0:
-                    logging.info(f"{utcnow()} Starting Sample generation. ")
+                    self.logger.info(f"{utcnow()} Starting Sample generation. ")
                 
                 fh = MPI.File.Open(comm, out_path_spec, amode)
                 samples_per_loop = int(MB * 16 / sample_size)
 
                 for sample_index in range(self.my_rank*samples_per_rank, samples_per_rank*(self.my_rank+1), samples_per_loop):
-                    #logging.info(f"{utcnow()} rank {self.my_rank} writing {sample_index} * {samples_per_loop} for {samples_per_rank} samples")
+                    #self.logger.info(f"{utcnow()} rank {self.my_rank} writing {sample_index} * {samples_per_loop} for {samples_per_rank} samples")
                     records = records = np.random.randint(255, size=sample_size*samples_per_loop, dtype=np.uint8)
                     offset = sample_index * sample_size
                     fh.Write_at_all(offset, records)

--- a/dlio_benchmark/data_generator/jpeg_generator.py
+++ b/dlio_benchmark/data_generator/jpeg_generator.py
@@ -51,10 +51,10 @@ class JPEGGenerator(DataGenerator):
             dim2 = dim[2*i+1]
             records = np.random.randint(255, size=(dim1, dim2), dtype=np.uint8)
             if self.my_rank==0:
-                logging.debug(f"{utcnow()} Dimension of images: {dim1} x {dim2}")
+                self.logger.debug(f"{utcnow()} Dimension of images: {dim1} x {dim2}")
             img = im.fromarray(records)
             if self.my_rank == 0 and i % 100 == 0:
-                logging.info(f"Generated file {i}/{self.total_files_to_generate}")
+                self.logger.info(f"Generated file {i}/{self.total_files_to_generate}")
             out_path_spec = self.storage.get_uri(self._file_list[i])
             progress(i+1, self.total_files_to_generate, "Generating JPEG Data")
             img.save(out_path_spec, format='JPEG', bits=8)

--- a/dlio_benchmark/data_generator/png_generator.py
+++ b/dlio_benchmark/data_generator/png_generator.py
@@ -46,12 +46,12 @@ class PNGGenerator(DataGenerator):
             dim1 = dim[2*i]
             dim2 = dim[2*i+1]
             if self.my_rank==0:
-                logging.debug(f"{utcnow()} Dimension of images: {dim1} x {dim2}")
+                self.logger.debug(f"{utcnow()} Dimension of images: {dim1} x {dim2}")
             out_path_spec = self.storage.get_uri(self._file_list[i])
             records = np.random.randint(255, size=(dim1, dim2), dtype=np.uint8)
             img = im.fromarray(records)
             if self.my_rank == 0 and i % 100 == 0:
-                logging.info(f"Generated file {i}/{self.total_files_to_generate}")
+                self.logger.info(f"Generated file {i}/{self.total_files_to_generate}")
             progress(i+1, self.total_files_to_generate, "Generating PNG Data")
             prev_out_spec = out_path_spec
             img.save(out_path_spec, format='PNG', bits=8)

--- a/dlio_benchmark/data_generator/synthetic_generator.py
+++ b/dlio_benchmark/data_generator/synthetic_generator.py
@@ -45,7 +45,7 @@ class SyntheticGenerator(DataGenerator):
         for i in dlp.iter(range(self.my_rank, int(self.total_files_to_generate), self.comm_size)):
             out_path_spec = self.storage.get_uri(self._file_list[i])
             if self.my_rank == 0 and i % 100 == 0:
-                logging.info(f"Generated file {i}/{self.total_files_to_generate}")
+                self.logger.info(f"Generated file {i}/{self.total_files_to_generate}")
             progress(i+1, self.total_files_to_generate, "Generating Synethic Data (Empty)")
             prev_out_spec = out_path_spec
             with open(out_path_spec, 'w') as f:

--- a/dlio_benchmark/data_loader/base_data_loader.py
+++ b/dlio_benchmark/data_loader/base_data_loader.py
@@ -35,6 +35,7 @@ class BaseDataLoader(ABC):
         self.data_loader_type = data_loader_type
         self.num_samples = self._args.total_samples_train if self.dataset_type is DatasetType.TRAIN else self._args.total_samples_eval
         self.batch_size = self._args.batch_size if self.dataset_type is DatasetType.TRAIN else self._args.batch_size_eval
+        self.logger = self._args.logger
 
     @abstractmethod
     def read(self):

--- a/dlio_benchmark/data_loader/data_loader_factory.py
+++ b/dlio_benchmark/data_loader/data_loader_factory.py
@@ -35,7 +35,7 @@ class DataLoaderFactory(object):
         _args = ConfigArguments.get_instance()
         if _args.data_loader_class is not None:
             if DLIOMPI.get_instance().rank() == 0:
-                logging.info(f"{utcnow()} Running DLIO with custom data loader class {_args.data_loader_class.__name__}")
+                _args.logger.info(f"{utcnow()} Running DLIO with custom data loader class {_args.data_loader_class.__name__}")
             return _args.data_loader_class(format_type, dataset_type, epoch)
         elif type == DataLoaderType.PYTORCH:
             from dlio_benchmark.data_loader.torch_data_loader import TorchDataLoader

--- a/dlio_benchmark/data_loader/native_dali_data_loader.py
+++ b/dlio_benchmark/data_loader/native_dali_data_loader.py
@@ -63,7 +63,7 @@ class NativeDaliDataLoader(BaseDataLoader):
                 # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
                 #       `dlp.iter(self._dataset, name=self.next.__qualname__)`
                 for batch in dlp.iter(self._dataset):
-                    logging.debug(f"{utcnow()} Creating {len(batch)} batches by {self._args.my_rank} rank ")
+                    self.logger.debug(f"{utcnow()} Creating {len(batch)} batches by {self._args.my_rank} rank ")
                     yield batch
             except StopIteration:
                 return

--- a/dlio_benchmark/data_loader/synthetic_data_loader.py
+++ b/dlio_benchmark/data_loader/synthetic_data_loader.py
@@ -44,7 +44,7 @@ class SyntheticDataLoader(BaseDataLoader):
     @dlp.log
     def next(self):
         super().next()
-        logging.debug(f"{utcnow()} Iterating pipelines by {self._args.my_rank} rank ")
+        self.logger.debug(f"{utcnow()} Iterating pipelines by {self._args.my_rank} rank ")
         step = 0
         self.read(True)
         while step < self.num_samples // self.batch_size:

--- a/dlio_benchmark/data_loader/tf_data_loader.py
+++ b/dlio_benchmark/data_loader/tf_data_loader.py
@@ -25,7 +25,7 @@ from dlio_benchmark.common.enumerations import DataLoaderType, Shuffle, FormatTy
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
 from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, DLIOLogger
 
 import numpy as np
 
@@ -38,7 +38,7 @@ class TensorflowDataset(tf.data.Dataset):
     def _generator(format_type, dataset_type, epoch_number, thread_index):
         format_type = format_type.decode('ascii')
         dataset_type = dataset_type.decode('ascii')
-        logging.debug(f"{utcnow()} format_type {format_type} dataset_type {dataset_type} tensors")
+        DLIOLogger.get_instance().debug(f"{utcnow()} format_type {format_type} dataset_type {dataset_type} tensors")
         reader = ReaderFactory.get_reader(type=FormatType.get_enum(format_type),
                                           dataset_type=DatasetType.get_enum(dataset_type),
                                           thread_index=thread_index,
@@ -69,7 +69,7 @@ class TFDataLoader(BaseDataLoader):
         read_threads = self._args.read_threads
         if read_threads == 0:
             if self._args.my_rank == 0:
-                logging.warning(
+                self.logger.warning(
                     f"{utcnow()} `read_threads` is set to be 0 for tf.data loader. We change it to 1")
             read_threads = 1
 

--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -51,6 +51,7 @@ class TorchDataset(Dataset):
         self.batch_size = batch_size
         args = ConfigArguments.get_instance()
         self.serial_args = pickle.dumps(args)
+        self.logger = args.logger
         self.dlp_logger = None
         if num_workers == 0:
             self.worker_init(-1)
@@ -61,7 +62,7 @@ class TorchDataset(Dataset):
         _args = ConfigArguments.get_instance()
         _args.configure_dlio_logging(is_child=True)
         self.dlp_logger = _args.configure_dftracer(is_child=True, use_pid=True)
-        logging.debug(f"{utcnow()} worker initialized {worker_id} with format {self.format_type}")
+        self.logger.debug(f"{utcnow()} worker initialized {worker_id} with format {self.format_type}")
         self.reader = ReaderFactory.get_reader(type=self.format_type,
                                                dataset_type=self.dataset_type,
                                                thread_index=worker_id,
@@ -79,7 +80,7 @@ class TorchDataset(Dataset):
     def __getitem__(self, image_idx):
         self.num_images_read += 1
         step = int(math.ceil(self.num_images_read / self.batch_size))
-        logging.debug(f"{utcnow()} Rank {DLIOMPI.get_instance().rank()} reading {image_idx} sample")
+        self.logger.debug(f"{utcnow()} Rank {DLIOMPI.get_instance().rank()} reading {image_idx} sample")
         dlp.update(step = step)
         return self.reader.read_index(image_idx, step)
 
@@ -121,14 +122,14 @@ class TorchDataLoader(BaseDataLoader):
             prefetch_factor = self._args.prefetch_size
         if prefetch_factor > 0:
             if self._args.my_rank == 0:
-                logging.debug(
+                self.logger.debug(
                     f"{utcnow()} Prefetch size is {self._args.prefetch_size}; prefetch factor of {prefetch_factor} will be set to Torch DataLoader.")
         else:
             prefetch_factor = 2
             if self._args.my_rank == 0:
-                logging.debug(
+                self.logger.debug(
                     f"{utcnow()} Prefetch size is 0; a default prefetch factor of 2 will be set to Torch DataLoader.")
-        logging.debug(f"{utcnow()} Setup dataloader with {self._args.read_threads} workers {torch.__version__}")
+        self.logger.debug(f"{utcnow()} Setup dataloader with {self._args.read_threads} workers {torch.__version__}")
         if self._args.read_threads==0:
             kwargs={}
         else:
@@ -156,7 +157,7 @@ class TorchDataLoader(BaseDataLoader):
                                        drop_last=True,
                                        worker_init_fn=dataset.worker_init,
                                        **kwargs)  # 2 is the default value
-        logging.debug(f"{utcnow()} Rank {self._args.my_rank} will read {len(self._dataset) * self.batch_size} files")
+        self.logger.debug(f"{utcnow()} Rank {self._args.my_rank} will read {len(self._dataset) * self.batch_size} files")
 
         # self._dataset.sampler.set_epoch(epoch_number)
 
@@ -164,7 +165,7 @@ class TorchDataLoader(BaseDataLoader):
     def next(self):
         super().next()
         total = self._args.training_steps if self.dataset_type is DatasetType.TRAIN else self._args.eval_steps
-        logging.debug(f"{utcnow()} Rank {self._args.my_rank} should read {total} batches")
+        self.logger.debug(f"{utcnow()} Rank {self._args.my_rank} should read {total} batches")
         step = 1
         # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
         #       `dlp.iter(self._dataset, name=self.next.__qualname__)`

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -35,7 +35,7 @@ import warnings
 warnings.filterwarnings("ignore", category=UserWarning)
 
 from dataclasses import dataclass
-from dlio_benchmark.utils.utility import utcnow, measure_performance, get_trace_name, DLIOMPI, DLIOOutput
+from dlio_benchmark.utils.utility import utcnow, measure_performance, get_trace_name, DLIOMPI
 from omegaconf import DictConfig, OmegaConf
 from dlio_benchmark.utils.statscounter import StatsCounter
 from hydra.core.config_store import ConfigStore
@@ -45,7 +45,7 @@ from dlio_benchmark.profiler.profiler_factory import ProfilerFactory
 from dlio_benchmark.framework.framework_factory import FrameworkFactory
 from dlio_benchmark.data_generator.generator_factory import GeneratorFactory
 from dlio_benchmark.storage.storage_factory import StorageFactory
-from dlio_benchmark.utils.utility import Profile, PerfTrace
+from dlio_benchmark.utils.utility import Profile, PerfTrace, DLIOLogger
 
 dlp = Profile(MODULE_DLIO_BENCHMARK)
 # To make sure the output folder is the same in all the nodes. We have to do this.
@@ -88,16 +88,16 @@ class DLIOBenchmark(object):
         if self.my_rank == 0:
             if os.path.isfile(self.args.logfile_path):
                 os.remove(self.args.logfile_path)
-        DLIOOutput.get_instance().initialize(self.args.logfile_path)
         self.comm.barrier()
         # Configure the logging library
         self.args.configure_dlio_logging(is_child=False)
+        self.logger = DLIOLogger.get_instance()
         self.dftracer = self.args.configure_dftracer(is_child=False, use_pid=False)
         with Profile(name=f"{self.__init__.__qualname__}", cat=MODULE_DLIO_BENCHMARK):
             if self.args.my_rank == 0:
-                DLIOOutput.print(f"{utcnow()} Running DLIO with {self.args.comm_size} process(es)")
+                self.logger.output(f"{utcnow()} Running DLIO with {self.args.comm_size} process(es)")
                 try:
-                    DLIOOutput.print(
+                    self.logger.output(
                         f"{utcnow()} Reading workload YAML config file '{hydra_cfg.runtime.config_sources[1]['path']}/workload/{hydra_cfg.runtime.choices.workload}.yaml'")
                 except:
                     pass
@@ -148,19 +148,19 @@ class DLIOBenchmark(object):
 
         if self.args.generate_data:
             if self.args.my_rank == 0:
-                DLIOOutput.print(f"{utcnow()} Starting data generation")
+                self.logger.output(f"{utcnow()} Starting data generation")
             self.data_generator.generate()
             # important to have this barrier to ensure that the data generation is done for all the ranks
             self.comm.barrier()
             if self.args.my_rank == 0:
-                DLIOOutput.print(f"{utcnow()} Generation done")
+                self.logger.output(f"{utcnow()} Generation done")
 
         if not self.generate_only and self.do_profiling:
             self.profiler.start()
             self.framework.start_framework_profiler()
             self.comm.barrier()
             if self.args.my_rank == 0:
-                logging.info(f"{utcnow()} Profiling Started with {self.args.profiler}")
+                self.logger.info(f"{utcnow()} Profiling Started with {self.args.profiler}")
         self.comm.barrier()
         file_list_train = []
         file_list_eval = []
@@ -188,7 +188,7 @@ class DLIOBenchmark(object):
                 fullpaths = [self.storage.get_uri(os.path.join(self.args.data_folder, f"{dataset_type}", entry))
                              for entry in filenames if entry.endswith(f'{self.args.format}')]
                 fullpaths = sorted(fullpaths)
-            logging.debug(f"subfolder {num_subfolders} fullpaths {fullpaths}")
+            self.logger.debug(f"subfolder {num_subfolders} fullpaths {fullpaths}")
             if dataset_type is DatasetType.TRAIN:
                 file_list_train = fullpaths
             elif dataset_type is DatasetType.VALID:
@@ -200,11 +200,11 @@ class DLIOBenchmark(object):
             raise Exception(
                 "Not enough evaluation dataset is found; Please run the code with ++workload.workflow.generate_data=True")
         if (self.num_files_train < len(file_list_train)):
-            logging.warning(
+            self.logger.warning(
                 f"Number of files for training in {os.path.join(self.args.data_folder, f'{DatasetType.TRAIN}')} ({len(file_list_train)}) is more than requested ({self.num_files_train}). A subset of files will be used ")
             file_list_train = file_list_train[:self.num_files_train]
         if (self.num_files_eval < len(file_list_eval)):
-            logging.warning(
+            self.logger.warning(
                 f"Number of files for evaluation in {os.path.join(self.args.data_folder, f'{DatasetType.VALID}')} ({len(file_list_eval)}) is more than requested ({self.num_files_eval}). A subset of files will be used ")
             file_list_eval = file_list_eval[:self.num_files_eval]
         self.args.derive_configurations(file_list_train, file_list_eval)
@@ -251,7 +251,7 @@ class DLIOBenchmark(object):
         for batch in loader.next():
             if overall_step > max_steps or ((self.total_training_steps > 0) and (overall_step > self.total_training_steps)):
                 if self.args.my_rank == 0:
-                    logging.info(f"{utcnow()} Maximum number of steps reached")
+                    self.logger.info(f"{utcnow()} Maximum number of steps reached")
                 if (block_step != 1 and self.do_checkpoint) or (not self.do_checkpoint):
                     self.stats.end_block(epoch, block, block_step - 1)
                 break
@@ -301,12 +301,12 @@ class DLIOBenchmark(object):
             # Print out the expected number of steps for each epoch and evaluation
             if self.my_rank == 0:
                 total = math.floor(self.num_samples * self.num_files_train / self.batch_size / self.comm_size)
-                DLIOOutput.print(
+                self.logger.output(
                     f"{utcnow()} Max steps per epoch: {total} = {self.num_samples} * {self.num_files_train} / {self.batch_size} / {self.comm_size} (samples per file * num files / batch size / comm size)")
 
                 if self.do_eval:
                     total = math.floor(self.num_samples * self.num_files_eval / self.batch_size_eval / self.comm_size)
-                    DLIOOutput.print(
+                    self.logger.output(
                         f"{utcnow()} Steps per eval: {total} = {self.num_samples} * {self.num_files_eval} / {self.batch_size_eval} / {self.comm_size} (samples per file * num files / batch size eval / comm size)")
 
             # Keep track of the next epoch at which we will evaluate
@@ -324,7 +324,7 @@ class DLIOBenchmark(object):
                 self.stats.start_train(epoch)
                 steps = self._train(epoch)
                 self.stats.end_train(epoch, steps)
-                logging.debug(f"{utcnow()} Rank {self.my_rank} returned after {steps} steps.")
+                self.logger.debug(f"{utcnow()} Rank {self.my_rank} returned after {steps} steps.")
                 self.framework.get_loader(DatasetType.TRAIN).finalize()
                 # Perform evaluation if enabled
                 if self.do_eval and epoch >= next_eval_epoch:
@@ -350,21 +350,20 @@ class DLIOBenchmark(object):
                 self.framework.stop_framework_profiler()
                 self.comm.barrier()
                 if self.my_rank == 0:
-                    logging.info(f"{utcnow()} Profiling stopped")
+                    self.logger.info(f"{utcnow()} Profiling stopped")
             if not self.args.keep_files:
-                logging.info(f"{utcnow()} Keep files set to False. Deleting dataset")
+                self.logger.info(f"{utcnow()} Keep files set to False. Deleting dataset")
                 self.comm.barrier()
                 if self.my_rank == 0:
                     if self.storage.get_node(self.args.data_folder):
                         self.storage.delete_node(self.args.data_folder)
-                        logging.info(f"{utcnow()} Deleted data files")
+                        self.logger.info(f"{utcnow()} Deleted data files")
 
             # Save collected stats to disk
             self.stats.finalize()
             self.stats.save_data()
         self.comm.barrier()
         self.args.finalize_dftracer(self.dftracer)
-        DLIOOutput.get_instance().finalize()
 
 
 @hydra.main(version_base=None, config_path="configs", config_name="config")

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -146,8 +146,6 @@ class DLIOBenchmark(object):
         - Start profiling session for Darshan and Tensorboard.
         """
         self.comm.barrier()
-        if self.args.debug and self.args.my_rank == 0:
-            input("Debug mode: Press enter to start\n")
 
         if self.args.generate_data:
             if self.args.my_rank == 0:

--- a/dlio_benchmark/reader/dali_image_reader.py
+++ b/dlio_benchmark/reader/dali_image_reader.py
@@ -56,7 +56,7 @@ class DaliImageReader(FormatReader):
 
     @dlp.log
     def pipeline(self):
-        logging.debug(
+        self.logger.debug(
             f"{utcnow()} Reading {len(self._file_list)} files rank {self._args.my_rank}")
         random_shuffle = False
         seed = -1

--- a/dlio_benchmark/reader/dali_npy_reader.py
+++ b/dlio_benchmark/reader/dali_npy_reader.py
@@ -41,7 +41,7 @@ class DaliNPYReader(FormatReader):
 
     @dlp.log
     def pipeline(self):
-        logging.debug(
+        self.logger.debug(
             f"{utcnow()} Reading {len(self._file_list)} files rank {self._args.my_rank}")
         random_shuffle = False
         seed = -1

--- a/dlio_benchmark/reader/dali_tfrecord_reader.py
+++ b/dlio_benchmark/reader/dali_tfrecord_reader.py
@@ -58,7 +58,7 @@ class DaliTFRecordReader(FormatReader):
         for file in self._file_list:
             filename = os.path.basename(file)
             index_files.append(f"{index_folder}/{filename}.idx")
-        logging.info(
+        self.logger.info(
             f"{utcnow()} Reading {len(self._file_list)} files rank {self._args.my_rank}")
         random_shuffle = False
         seed = -1

--- a/dlio_benchmark/reader/image_reader.py
+++ b/dlio_benchmark/reader/image_reader.py
@@ -46,7 +46,7 @@ class ImageReader(FormatReader):
 
     @dlp.log
     def get_sample(self, filename, sample_index):
-        logging.debug(f"{utcnow()} sample_index {sample_index}, {self.image_idx}")
+        self.logger.debug(f"{utcnow()} sample_index {sample_index}, {self.image_idx}")
         super().get_sample(filename, sample_index)
         image = self.open_file_map[filename]
         dlp.update(image_size=image.nbytes)

--- a/dlio_benchmark/reader/indexed_binary_reader.py
+++ b/dlio_benchmark/reader/indexed_binary_reader.py
@@ -56,11 +56,11 @@ class IndexedBinaryReader(FormatReader):
             self.file_map_ibr[filename] = []
             with open(offset_file, 'rb') as f:
                 offsets = self.read_longs(f, self._args.num_samples_per_file)
-                logging.debug(f"read offsets {offsets} from file {offset_file}")
+                self.logger.debug(f"read offsets {offsets} from file {offset_file}")
                 self.file_map_ibr[filename].append(offsets)
             with open(sz_file, 'rb') as f:
                 sizes = self.read_longs(f, self._args.num_samples_per_file)
-                logging.debug(f"read sizes {sizes} from file {sz_file}")
+                self.logger.debug(f"read sizes {sizes} from file {sz_file}")
                 self.file_map_ibr[filename].append(sizes)
     @dlp.log
     def load_index(self):
@@ -90,7 +90,7 @@ class IndexedBinaryReader(FormatReader):
         file = self.open_file_map[filename]
         offset = self.file_map_ibr[filename][0][sample_index]
         size = self.file_map_ibr[filename][1][sample_index]
-        logging.debug(f"reading sample from offset {offset} of size {size} from file {filename}")
+        self.logger.debug(f"reading sample from offset {offset} of size {size} from file {filename}")
         file.seek(offset)
         image = np.empty(size, dtype=np.uint8)
         file.readinto(image)

--- a/dlio_benchmark/reader/reader_factory.py
+++ b/dlio_benchmark/reader/reader_factory.py
@@ -36,7 +36,7 @@ class ReaderFactory(object):
         _args = ConfigArguments.get_instance()
         if _args.reader_class is not None:
             if DLIOMPI.get_instance().rank() == 0:
-                logging.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
+                self.logger.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
             return _args.reader_class(dataset_type, thread_index, epoch_number)
         elif type == FormatType.HDF5:
             from dlio_benchmark.reader.hdf5_reader import HDF5Reader

--- a/dlio_benchmark/reader/reader_handler.py
+++ b/dlio_benchmark/reader/reader_handler.py
@@ -39,7 +39,8 @@ class FormatReader(ABC):
     def __init__(self, dataset_type, thread_index):
         self.thread_index = thread_index
         self._args = ConfigArguments.get_instance()
-        logging.debug(
+        self.logger = self._args.logger
+        self.logger.debug(
             f"Loading {self.__class__.__qualname__} reader on thread {self.thread_index} from rank {self._args.my_rank}")
         self.dataset_type = dataset_type
         self.open_file_map = {}
@@ -81,7 +82,7 @@ class FormatReader(ABC):
         image_processed = 0
         self.step = 1
         total_images = len(self.file_map[self.thread_index])
-        logging.debug(f"{utcnow()} Reading {total_images} images thread {self.thread_index} rank {self._args.my_rank}")
+        self.logger.debug(f"{utcnow()} Reading {total_images} images thread {self.thread_index} rank {self._args.my_rank}")
 
         for global_sample_idx, filename, sample_index in self.file_map[self.thread_index]:
             self.image_idx = global_sample_idx
@@ -110,9 +111,9 @@ class FormatReader(ABC):
     def read_index(self, global_sample_idx, step):
         self.step = step
         self.image_idx = global_sample_idx
-        logging.debug(f"{self.global_index_map}")
+        self.logger.debug(f"{self.global_index_map}")
         filename, sample_index = self.global_index_map[global_sample_idx]
-        logging.debug(f"{utcnow()} read_index {filename}, {sample_index}")
+        self.logger.debug(f"{utcnow()} read_index {filename}, {sample_index}")
         FormatReader.read_images += 1
         if self._args.read_type is ReadType.ON_DEMAND or filename not in self.open_file_map or self.open_file_map[filename] is None:
             self.open_file_map[filename] = self.open(filename)

--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -81,12 +81,12 @@ class TFReader(FormatReader):
 
     @dlp.log
     def next(self):
-        logging.debug(f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
+        self.logger.debug(f"{utcnow()} Reading {len(self._file_list)} files thread {self.thread_index} rank {self._args.my_rank}")
         filenames = tf.data.Dataset.list_files(self._file_list, shuffle=False)
         # sharding in the file list if we have enought files. 
         if (len(self._file_list) >= self._args.comm_size):
             filenames = filenames.shard(num_shards=self._args.comm_size, index=self._args.my_rank)
-            logging.debug(f"{utcnow()} shard {filenames} files index {self._args.my_rank} number {self._args.comm_size}")
+            self.logger.debug(f"{utcnow()} shard {filenames} files index {self._args.my_rank} number {self._args.comm_size}")
         
         self._dataset = tf.data.TFRecordDataset(filenames=filenames, buffer_size=self._args.transfer_size,
                                                 num_parallel_reads=self._args.read_threads)

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -26,7 +26,7 @@ from typing import List, ClassVar
 
 from dlio_benchmark.common.constants import MODULE_CONFIG
 from dlio_benchmark.common.enumerations import StorageType, FormatType, Shuffle, ReadType, FileAccess, Compression, \
-    FrameworkType, \
+    FrameworkType, LogLevel, \
     DataLoaderType, Profiler, DatasetType, DataLoaderSampler, CheckpointLocationType, CheckpointMechanismType
 from dlio_benchmark.utils.utility import DLIOMPI, get_trace_name, utcnow
 from dataclasses import dataclass
@@ -91,7 +91,7 @@ class ConfigArguments:
     chunk_size: int = 0
     compression: Compression = Compression.NONE
     compression_level: int = 4
-    debug: bool = False
+    log_level: LogLevel = LogLevel.INFO
     total_training_steps: int = -1
     do_eval: bool = False
     batch_size_eval: int = 1
@@ -167,7 +167,12 @@ class ConfigArguments:
         if is_child and self.multiprocessing_context == "fork":
             return
         # Configure the logging library
-        log_level = logging.DEBUG if self.debug else logging.INFO
+        if self.log_level == LogLevel.DEBUG:
+            log_level = logging.DEBUG
+        elif self.log_level == LogLevel.WARN
+            log_level = logging.WARN
+        else:
+            log_level = logging.INFO
         logging.basicConfig(
             level=log_level,
             force=True,
@@ -569,8 +574,8 @@ def LoadConfig(args, config):
             args.generate_only = True
         else:
             args.generate_only = False
-        if 'debug' in config['workflow']:
-            args.debug = config['workflow']['debug']
+        if 'log_level' in config['workflow']:
+            args.log_level = LogLevel(config['workflow']['log_level'])
         if 'evaluation' in config['workflow']:
             args.do_eval = config['workflow']['evaluation']
         if 'checkpoint' in config['workflow']:

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -174,8 +174,8 @@ class ConfigArguments:
         if self.log_level == LogLevel.DEBUG:
             log_level = logging.DEBUG
             log_format = log_format_verbose 
-        elif self.log_level == LogLevel.WARN:
-            log_level = logging.WARN
+        elif self.log_level == LogLevel.WARNING:
+            log_level = logging.WARNING
         elif self.log_level == LogLevel.ERROR:
             log_level = logging.ERROR
         else:
@@ -553,7 +553,8 @@ def LoadConfig(args, config):
             args.output_folder = config['output']['folder']
         if 'log_file' in config['output']:
             args.log_file = config['output']['log_file']
-
+        if 'log_level' in config['output']:
+            args.log_level = LogLevel(config['output']['log_level'])
     if args.output_folder is None:
         try:
             hydra_cfg = hydra.core.hydra_config.HydraConfig.get()
@@ -569,8 +570,6 @@ def LoadConfig(args, config):
             args.generate_only = True
         else:
             args.generate_only = False
-        if 'log_level' in config['workflow']:
-            args.log_level = LogLevel(config['workflow']['log_level'])
         if 'evaluation' in config['workflow']:
             args.do_eval = config['workflow']['evaluation']
         if 'checkpoint' in config['workflow']:

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -167,10 +167,17 @@ class ConfigArguments:
         if is_child and self.multiprocessing_context == "fork":
             return
         # Configure the logging library
+        log_format_verbose = '[%(levelname)s] %(message)s [%(pathname)s:%(lineno)d]'
+        log_format_simple = '[%(levelname)s] %(message)s'
+        # Set logging format to be simple only when debug_level <= INFO
+        log_format = log_format_simple
         if self.log_level == LogLevel.DEBUG:
             log_level = logging.DEBUG
+            log_format = log_format_verbose 
         elif self.log_level == LogLevel.WARN:
             log_level = logging.WARN
+        elif self.log_level == LogLevel.ERROR:
+            log_level = logging.ERROR
         else:
             log_level = logging.INFO
         logging.basicConfig(
@@ -180,10 +187,9 @@ class ConfigArguments:
                 logging.FileHandler(self.logfile_path, mode="a", encoding='utf-8'),
                 logging.StreamHandler()
             ],
-            format='[%(levelname)s] %(message)s [%(pathname)s:%(lineno)d]'
+            format = log_format
             # logging's max timestamp resolution is msecs, we will pass in usecs in the message
         )
-
     def configure_dftracer(self, is_child=False, use_pid=False):
         # with "multiprocessing_context=fork" the profiler file remains open in the child process
         if is_child and self.multiprocessing_context == "fork":

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -91,7 +91,7 @@ class ConfigArguments:
     chunk_size: int = 0
     compression: Compression = Compression.NONE
     compression_level: int = 4
-    log_level: LogLevel = LogLevel.INFO
+    log_level: LogLevel = LogLevel.WARNING
     total_training_steps: int = -1
     do_eval: bool = False
     batch_size_eval: int = 1
@@ -171,6 +171,8 @@ class ConfigArguments:
         log_format_simple = '[%(levelname)s] %(message)s'
         # Set logging format to be simple only when debug_level <= INFO
         log_format = log_format_simple
+        if 'DLIO_LOG_LEVEL' in os.environ:
+            self.log_level = LogLevel(os.environ["DLIO_LOG_LEVEL"])
         if self.log_level == LogLevel.DEBUG:
             log_level = logging.DEBUG
             log_format = log_format_verbose 
@@ -178,8 +180,11 @@ class ConfigArguments:
             log_level = logging.WARNING
         elif self.log_level == LogLevel.ERROR:
             log_level = logging.ERROR
-        else:
+        elif self.log_level == LogLevel.INFO:
             log_level = logging.INFO
+        else:
+            log_level = logging.WARNING
+
         logging.basicConfig(
             level=log_level,
             force=True,
@@ -553,8 +558,6 @@ def LoadConfig(args, config):
             args.output_folder = config['output']['folder']
         if 'log_file' in config['output']:
             args.log_file = config['output']['log_file']
-        if 'log_level' in config['output']:
-            args.log_level = LogLevel(config['output']['log_level'])
     if args.output_folder is None:
         try:
             hydra_cfg = hydra.core.hydra_config.HydraConfig.get()

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -26,10 +26,10 @@ from typing import Any, Dict, List, ClassVar
 
 from dlio_benchmark.common.constants import MODULE_CONFIG
 from dlio_benchmark.common.enumerations import StorageType, FormatType, Shuffle, ReadType, FileAccess, Compression, \
-    FrameworkType, LogLevel, \
+    FrameworkType, \
     DataLoaderType, Profiler, DatasetType, DataLoaderSampler, CheckpointLocationType, CheckpointMechanismType
 from dlio_benchmark.utils.utility import DLIOMPI, get_trace_name, utcnow
-from dlio_benchmark.utils.utility import Profile, PerfTrace, DFTRACER_ENABLE, DLIOLogger
+from dlio_benchmark.utils.utility import Profile, PerfTrace, DFTRACER_ENABLE, DLIOLogger, OUTPUT_LEVEL
 from dataclasses import dataclass
 from omegaconf import OmegaConf, DictConfig
 import math
@@ -66,7 +66,7 @@ class ConfigArguments:
     seed_change_epoch: bool = True
     generate_data: bool = False
     generate_only: bool = False
-    log_level: int = logging.WARNING
+    log_level: int = OUTPUT_LEVEL
     data_folder: str = "./data/"
     output_folder: str = None
     checkpoint_folder: str = "./checkpoints/"

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -169,7 +169,7 @@ class ConfigArguments:
         # Configure the logging library
         if self.log_level == LogLevel.DEBUG:
             log_level = logging.DEBUG
-        elif self.log_level == LogLevel.WARN
+        elif self.log_level == LogLevel.WARN:
             log_level = logging.WARN
         else:
             log_level = logging.INFO

--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -182,7 +182,7 @@ class StatsCounter(object):
                     metric = metric + f"[METRIC] Eval Throughput (MB/second): {np.mean(eval_throughput)*self.record_size/1024/1024:.6f} ({np.std(eval_throughput)*self.record_size/1024/1024:.6f})\n"
                     metric = metric + f"[METRIC] eval_au_meet_expectation: {self.summary['metric']['eval_au_meet_expectation']}\n"
                 metric+="[METRIC] ==========================================================\n"
-                logging.info(metric)   
+                print(metric)   
     def start_train(self, epoch):   
         if self.my_rank == 0:
             ts = utcnow()
@@ -282,8 +282,8 @@ class StatsCounter(object):
             logging.info(f"{ts} Ending block {block} - {steps_taken} steps completed in {duration} s")
             self.per_epoch_stats[epoch][f'block{block}']['end'] = ts
             self.per_epoch_stats[epoch][f'block{block}']['duration'] = duration
-            logging.info(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Accelerator Utilization [AU] (%): {self.output[epoch]['au'][f'block{block}']:.4f}")
-            logging.info(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Throughput (samples/second): {self.output[epoch]['throughput'][f'block{block}']*self.comm_size:.4f}")
+            print(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Accelerator Utilization [AU] (%): {self.output[epoch]['au'][f'block{block}']:.4f}")
+            print(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Throughput (samples/second): {self.output[epoch]['throughput'][f'block{block}']*self.comm_size:.4f}")
 
     def start_ckpt(self, epoch, block, steps_taken):
         if self.my_rank == 0:

--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -358,7 +358,7 @@ class StatsCounter(object):
         duration = time() - t0
         self.output[epoch]['proc']['eval'].append(duration)
         self.output[epoch]['compute']['eval'].append(computation_time)
-        logging.info(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size_eval} samples in {duration} s")
+        logging.debug(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size_eval} samples in {duration} s")
     def finalize(self):
         self.summary['end'] = utcnow()
     def save_data(self):

--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -182,7 +182,7 @@ class StatsCounter(object):
                     metric = metric + f"[METRIC] Eval Throughput (MB/second): {np.mean(eval_throughput)*self.record_size/1024/1024:.6f} ({np.std(eval_throughput)*self.record_size/1024/1024:.6f})\n"
                     metric = metric + f"[METRIC] eval_au_meet_expectation: {self.summary['metric']['eval_au_meet_expectation']}\n"
                 metric+="[METRIC] ==========================================================\n"
-                print(metric)   
+                logging.info(metric)   
     def start_train(self, epoch):   
         if self.my_rank == 0:
             ts = utcnow()
@@ -282,8 +282,8 @@ class StatsCounter(object):
             logging.info(f"{ts} Ending block {block} - {steps_taken} steps completed in {duration} s")
             self.per_epoch_stats[epoch][f'block{block}']['end'] = ts
             self.per_epoch_stats[epoch][f'block{block}']['duration'] = duration
-            print(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Accelerator Utilization [AU] (%): {self.output[epoch]['au'][f'block{block}']:.4f}")
-            print(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Throughput (samples/second): {self.output[epoch]['throughput'][f'block{block}']*self.comm_size:.4f}")
+            logging.info(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Accelerator Utilization [AU] (%): {self.output[epoch]['au'][f'block{block}']:.4f}")
+            logging.info(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Throughput (samples/second): {self.output[epoch]['throughput'][f'block{block}']*self.comm_size:.4f}")
 
     def start_ckpt(self, epoch, block, steps_taken):
         if self.my_rank == 0:

--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -16,7 +16,7 @@
 """
 from numpy import append
 from dlio_benchmark.utils.config import ConfigArguments
-from dlio_benchmark.utils.utility import utcnow, DLIOMPI, DLIOOutput
+from dlio_benchmark.utils.utility import utcnow, DLIOMPI, DLIOLogger
 
 import os
 import json
@@ -46,6 +46,7 @@ class StatsCounter(object):
 
     def __init__(self):
         self.MPI = DLIOMPI.get_instance()
+        self.logger = DLIOLogger.get_instance()
         self.comm = self.MPI.comm()
         self.args = ConfigArguments.get_instance()
         self.my_rank = self.args.my_rank
@@ -75,7 +76,7 @@ class StatsCounter(object):
 
         if self.args.total_training_steps > 0:
             if self.args.total_training_steps > max_steps:
-                logging.error(f"Only have enough data for {max_steps} steps but {self.args.total_training_steps} wanted")
+                self.logger.error(f"Only have enough data for {max_steps} steps but {self.args.total_training_steps} wanted")
                 exit(-1)
             self.steps_override = True
             self.steps = self.args.total_training_steps
@@ -118,11 +119,11 @@ class StatsCounter(object):
         data_per_node = self.MPI.npernode()*self.args.num_samples_per_file * self.args.num_files_train//self.MPI.size()*self.args.record_length
         self.summary['data_size_per_host_GB'] = data_per_node/1024./1024./1024.
         if self.MPI.rank() == 0:
-            logging.info(f"Total amount of data each host will consume is {data_per_node/1024./1024./1024} GB; each host has {self.summary['host_memory_GB'][0]} GB memory") 
+            self.logger.info(f"Total amount of data each host will consume is {data_per_node/1024./1024./1024} GB; each host has {self.summary['host_memory_GB'][0]} GB memory") 
         if self.summary['data_size_per_host_GB'] <= self.output['host_memory_GB']:
             self.output['potential_caching'] = 1
             if self.MPI.rank() == 0: 
-                logging.warning(f"The amount of dataset ({self.summary['data_size_per_host_GB']:.4f} GB) is smaller than the host memory ({self.summary['host_memory_GB'][0]} GB); data might be cached after the first epoch. Increase the size of dataset to eliminate the caching effect!!!")
+                self.logger.warning(f"The amount of dataset ({self.summary['data_size_per_host_GB']:.4f} GB) is smaller than the host memory ({self.summary['host_memory_GB'][0]} GB); data might be cached after the first epoch. Increase the size of dataset to eliminate the caching effect!!!")
         potential_caching = []
         for i in range(self.MPI.size()//self.MPI.npernode()):
             if self.summary['host_memory_GB'][i]  <= self.summary['data_size_per_host_GB']:
@@ -168,7 +169,7 @@ class StatsCounter(object):
                 self.summary['metric']['eval_io_mean_MB_per_second'] = np.mean(eval_throughput)*self.record_size/1024./1024.
                 self.summary['metric']['eval_io_stdev_MB_per_second'] = np.std(eval_throughput)*self.record_size/1024./1024.
             if self.my_rank==0:
-                DLIOOutput.print(f"{utcnow()} Saved outputs in {self.output_folder}")   
+                self.logger.output(f"{utcnow()} Saved outputs in {self.output_folder}")   
                 metric="Averaged metric over all epochs\n[METRIC] ==========================================================\n"
                 metric = metric + f"[METRIC] Number of Simulated Accelerators: {self.comm_size} \n"
                 metric = metric + f"[METRIC] Training Accelerator Utilization [AU] (%): {np.mean(train_au):.4f} ({np.std(train_au):.4f})\n"
@@ -182,14 +183,14 @@ class StatsCounter(object):
                     metric = metric + f"[METRIC] Eval Throughput (MB/second): {np.mean(eval_throughput)*self.record_size/1024/1024:.6f} ({np.std(eval_throughput)*self.record_size/1024/1024:.6f})\n"
                     metric = metric + f"[METRIC] eval_au_meet_expectation: {self.summary['metric']['eval_au_meet_expectation']}\n"
                 metric+="[METRIC] ==========================================================\n"
-                DLIOOutput.print(metric)   
+                self.logger.output(metric)   
     def start_train(self, epoch):   
         if self.my_rank == 0:
             ts = utcnow()
             if self.steps_override:
-                DLIOOutput.print(f"{ts} Starting epoch {epoch}: Overriding number of steps to {self.steps}.")
+                self.logger.output(f"{ts} Starting epoch {epoch}: Overriding number of steps to {self.steps}.")
             else:
-                DLIOOutput.print(f"{ts} Starting epoch {epoch}: {self.steps} steps expected")
+                self.logger.output(f"{ts} Starting epoch {epoch}: {self.steps} steps expected")
             self.per_epoch_stats[epoch] = {
                 'start': ts,
             }
@@ -222,13 +223,13 @@ class StatsCounter(object):
             duration = '{:.2f}'.format(duration.total_seconds())
             self.per_epoch_stats[epoch]['end'] = ts
             self.per_epoch_stats[epoch]['duration'] = duration
-            DLIOOutput.print(f"{ts} Ending epoch {epoch} - {np.sum(steps)} steps completed in {duration} s")
+            self.logger.output(f"{ts} Ending epoch {epoch} - {np.sum(steps)} steps completed in {duration} s")
 
     def start_eval(self, epoch):
         self.start_timestamp = time()
         if self.my_rank == 0:
             ts = utcnow()
-            DLIOOutput.print(f"{ts} Starting eval - {self.steps_eval} steps expected")
+            self.logger.output(f"{ts} Starting eval - {self.steps_eval} steps expected")
             self.per_epoch_stats[epoch]['eval'] = {
                 'start': ts
             }
@@ -246,11 +247,11 @@ class StatsCounter(object):
             ts = utcnow()
             duration = pd.to_datetime(ts)- pd.to_datetime(self.per_epoch_stats[epoch]['eval']['start'])
             duration = '{:.2f}'.format(duration.total_seconds())
-            DLIOOutput.print(f"{ts} Ending eval - {self.steps_eval} steps completed in {duration} s")
+            self.logger.output(f"{ts} Ending eval - {self.steps_eval} steps completed in {duration} s")
             self.per_epoch_stats[epoch]['eval']['end'] = ts
             self.per_epoch_stats[epoch]['eval']['duration'] = duration        
-            DLIOOutput.print(f"{utcnow()} Epoch {epoch} [Eval] Accelerator Utilization [AU] (%): {self.output[epoch]['au']['eval']:.4f}")
-            DLIOOutput.print(f"{utcnow()} Epoch {epoch} [Eval] Throughput (samples/second): {self.output[epoch]['throughput']['eval']*self.comm_size:.4f}")
+            self.logger.output(f"{utcnow()} Epoch {epoch} [Eval] Accelerator Utilization [AU] (%): {self.output[epoch]['au']['eval']:.4f}")
+            self.logger.output(f"{utcnow()} Epoch {epoch} [Eval] Throughput (samples/second): {self.output[epoch]['throughput']['eval']*self.comm_size:.4f}")
 
     def start_block(self, epoch, block):
         self.start_timestamp = time()
@@ -261,7 +262,7 @@ class StatsCounter(object):
         self.output[epoch]['compute'][f'block{block}'] = []
         if self.my_rank == 0:
             ts = utcnow()
-            DLIOOutput.print(f"{ts} Starting block {block}")
+            self.logger.output(f"{ts} Starting block {block}")
             self.per_epoch_stats[epoch][f'block{block}'] = {
                 'start': ts
             }
@@ -279,16 +280,16 @@ class StatsCounter(object):
             ts = utcnow()
             duration = pd.to_datetime(ts) - pd.to_datetime(self.per_epoch_stats[epoch][f'block{block}']['start'])
             duration = '{:.2f}'.format(duration.total_seconds())
-            DLIOOutput.print(f"{ts} Ending block {block} - {steps_taken} steps completed in {duration} s")
+            self.logger.output(f"{ts} Ending block {block} - {steps_taken} steps completed in {duration} s")
             self.per_epoch_stats[epoch][f'block{block}']['end'] = ts
             self.per_epoch_stats[epoch][f'block{block}']['duration'] = duration
-            DLIOOutput.print(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Accelerator Utilization [AU] (%): {self.output[epoch]['au'][f'block{block}']:.4f}")
-            DLIOOutput.print(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Throughput (samples/second): {self.output[epoch]['throughput'][f'block{block}']*self.comm_size:.4f}")
+            self.logger.output(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Accelerator Utilization [AU] (%): {self.output[epoch]['au'][f'block{block}']:.4f}")
+            self.logger.output(f"{utcnow()} Epoch {epoch} - Block {block} [Training] Throughput (samples/second): {self.output[epoch]['throughput'][f'block{block}']*self.comm_size:.4f}")
 
     def start_ckpt(self, epoch, block, steps_taken):
         if self.my_rank == 0:
             ts = utcnow()
-            DLIOOutput.print(f"{ts} Starting checkpoint {block} after total step {steps_taken} for epoch {epoch}")
+            self.logger.output(f"{ts} Starting checkpoint {block} after total step {steps_taken} for epoch {epoch}")
             self.per_epoch_stats[epoch][f'ckpt{block}'] = {
                 'start': ts
             }
@@ -298,7 +299,7 @@ class StatsCounter(object):
             ts = utcnow()
             duration = pd.to_datetime(ts) - pd.to_datetime(self.per_epoch_stats[epoch][f'ckpt{block}']['start'])
             duration = '{:.2f}'.format(duration.total_seconds())
-            DLIOOutput.print(f"{ts} Ending checkpoint {block} for epoch {epoch}")
+            self.logger.output(f"{ts} Ending checkpoint {block} for epoch {epoch}")
 
             self.per_epoch_stats[epoch][f'ckpt{block}']['end'] = ts
             self.per_epoch_stats[epoch][f'ckpt{block}']['duration'] = duration
@@ -310,7 +311,7 @@ class StatsCounter(object):
             self.output[epoch]['load'][key].append(duration)
         else:
             self.output[epoch]['load'][key] = [duration]
-        logging.info(f"{utcnow()} Rank {self.my_rank} step {step}: loaded {self.batch_size} samples in {duration} s")
+        self.logger.info(f"{utcnow()} Rank {self.my_rank} step {step}: loaded {self.batch_size} samples in {duration} s")
 
 
     def batch_processed(self, epoch, step, block, t0, computation_time):
@@ -322,7 +323,7 @@ class StatsCounter(object):
         else:
             self.output[epoch]['proc'] = [duration]
             self.output[epoch]['compute']=[computation_time]
-        logging.info(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size} samples in {duration} s")
+        self.logger.info(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size} samples in {duration} s")
 
     def compute_metrics_train(self, epoch, block):
         key = f"block{block}"
@@ -351,14 +352,14 @@ class StatsCounter(object):
     def eval_batch_loaded(self, epoch, step, t0):
         duration = time() - t0
         self.output[epoch]['load']['eval'].append(duration)
-        logging.info(f"{utcnow()} Rank {self.my_rank} step {step} loaded {self.batch_size_eval} samples in {duration} s")
+        self.logger.info(f"{utcnow()} Rank {self.my_rank} step {step} loaded {self.batch_size_eval} samples in {duration} s")
 
 
     def eval_batch_processed(self, epoch, step, t0, computation_time):
         duration = time() - t0
         self.output[epoch]['proc']['eval'].append(duration)
         self.output[epoch]['compute']['eval'].append(computation_time)
-        logging.info(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size_eval} samples in {duration} s")
+        self.logger.info(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size_eval} samples in {duration} s")
     def finalize(self):
         self.summary['end'] = utcnow()
     def save_data(self):
@@ -375,6 +376,6 @@ class StatsCounter(object):
             json.dump(self.output, outfile, indent=4)
             outfile.flush()
         if self.my_rank == 0:
-            DLIOOutput.print(f"{utcnow()} outputs saved in RANKID_output.json")
+            self.logger.output(f"{utcnow()} outputs saved in RANKID_output.json")
 
 

--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -322,7 +322,7 @@ class StatsCounter(object):
         else:
             self.output[epoch]['proc'] = [duration]
             self.output[epoch]['compute']=[computation_time]
-        logging.info(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size} samples in {duration} s")
+        logging.debug(f"{utcnow()} Rank {self.my_rank} step {step} processed {self.batch_size} samples in {duration} s")
 
     def compute_metrics_train(self, epoch, block):
         key = f"block{block}"

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -56,7 +56,7 @@ except:
         def reset(self):
             return
         def log_static(self, func):
-            return
+            return func
     class dftracer(object):
         def __init__(self,):
             self.type = None

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -40,11 +40,11 @@ except:
         def __init__(self,  cat, name=None, epoch=None, step=None, image_idx=None, image_size=None):
             return 
         def log(self,  func):
-            return 
+            return func
         def log_init(self,  func):
-            return 
+            return func
         def iter(self,  func, iter_name="step"):
-            return 
+            return func
         def __enter__(self):
             return
         def __exit__(self, type, value, traceback):

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -89,14 +89,13 @@ class DLIOLogger:
     __instance = None
 
     def __init__(self):
-        self.logger = None
+        console_handler = logging.StreamHandler()
+        self.logger = logging.getLogger("DLIO")
+        #self.logger.setLevel(logging.DEBUG)
         if DLIOLogger.__instance is not None:
             raise Exception(f"Class {self.classname()} is a singleton!")
         else:
             DLIOLogger.__instance = self
-        console_handler = logging.StreamHandler()
-        self.logger = logging.getLogger("DLIO")
-        self.logger.setLevel(logging.WARNING)
     @staticmethod
     def get_instance():
         if DLIOLogger.__instance is None:

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -37,30 +37,30 @@ try:
     from dftracer.logger import dftracer as PerfTrace, dft_fn as Profile, DFTRACER_ENABLE as DFTRACER_ENABLE
 except:
     class Profile(object):
-        def __init__(self,  **kwargs):
+        def __init__(self,  cat, name=None, epoch=None, step=None, image_idx=None, image_size=None):
             return 
-        def log(self,  **kwargs):
+        def log(self,  func):
             return 
-        def log_init(self,  **kwargs):
+        def log_init(self,  func):
             return 
-        def iter(self,  **kwargs):
+        def iter(self,  func, iter_name="step"):
             return 
         def __enter__(self):
             return
-        def __exit__(self, **kwargs):
+        def __exit__(self, type, value, traceback):
             return
-        def update(self, **kwargs):
+        def update(self, epoch=None, step=None, image_idx=None, image_size=None, args={}):
             return
         def flush(self):
             return
         def reset(self):
             return
-        def log_static(self, **kwargs):
+        def log_static(self, func):
             return
     class dftracer(object):
         def __init__(self,):
             self.type = None
-        def initialize_log(self, **kwargs):
+        def initialize_log(self, logfile=None, data_dir=None, process_id=-1):
             return
         def get_time(self):
             return
@@ -68,7 +68,7 @@ except:
             return
         def exit_event(self):
             return
-        def log_event(self,  **kwargs):
+        def log_event(self, name, cat, start_time, duration, string_args=None):
             return
         def finalize(self):
             return

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -37,27 +37,42 @@ try:
     from dftracer.logger import dftracer as PerfTrace, dft_fn as Profile, DFTRACER_ENABLE as DFTRACER_ENABLE
 except:
     class Profile(object):
-        def __init__(self, name=None, cat=None):
-            self.type = type
-        def log(self, func):
-            return func
-        def log_init(self, func):
-            return func
-        def iter(self, a):
-            return a
+        def __init__(self,  **kwargs):
+            return 
+        def log(self,  **kwargs):
+            return 
+        def log_init(self,  **kwargs):
+            return 
+        def iter(self,  **kwargs):
+            return 
         def __enter__(self):
             return
-        def __exit__(self, type, value, traceback):
+        def __exit__(self, **kwargs):
             return
-        def update(self, *, epoch=0, step=0, size=0, default=None):
+        def update(self, **kwargs):
+            return
+        def flush(self):
+            return
+        def reset(self):
+            return
+        def log_static(self, **kwargs):
             return
     class dftracer(object):
         def __init__(self,):
             self.type = None
-        def initialize_log(self, logfile=None, data_dir=None, process_id=-1):
+        def initialize_log(self, **kwargs):
             return
-        def iter(self, a):
-            return a
+        def get_time(self):
+            return
+        def enter_event(self):
+            return
+        def exit_event(self):
+            return
+        def log_event(self,  **kwargs):
+            return
+        def finalize(self):
+            return
+        
     PerfTrace = dftracer()
     DFTRACER_ENABLE = False
 

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -301,3 +301,36 @@ def get_trace_name(output_folder, use_pid=False):
     if use_pid:
         val = f"-{os.getpid()}"
     return f"{output_folder}/trace-{DLIOMPI.get_instance().rank()}-of-{DLIOMPI.get_instance().size()}{val}.pfw"
+
+
+
+class DLIOOutput:
+    __instance = None
+
+    def __init__(self):
+        self.fout = None
+        if DLIOOutput.__instance is not None:
+            raise Exception(f"Class {self.classname()} is a singleton!")
+        else:
+            DLIOOutput.__instance = self
+
+    @staticmethod
+    def get_instance():
+        if DLIOOutput.__instance is None:
+            DLIOOutput()
+        return DLIOOutput.__instance
+
+    @staticmethod
+    def reset():
+        DLIOOutput.__instance = None
+
+    @classmethod
+    def classname(cls):
+        return cls.__qualname__
+    def initialize(self, filename):
+        self.fout = open(filename, "w+")
+    def finalize(self):
+        self.fout.close()
+    def print(msg, flush=True):
+        print(msg, flush=flush)
+        DLIOOutput.__instance.fout.write(f"{msg}\n")

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -458,7 +458,10 @@ Environment variables
 ============================================
 There are a few environment variables that controls and logging and profiling information. 
 
-
+.. list-table:: 
+   :widths: 15 10 30
+   :header-rows: 1
+   
    * - Variable name
      - Default
      - Description

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -102,7 +102,7 @@ workflow
      - whether to perform profiling
    * - log_level
      - "info"
-     - select the logging level [warn|info|debug]
+     - select the logging level [error|warn|info|debug|]
 
 .. note:: 
 
@@ -113,6 +113,7 @@ workflow
 .. note:: 
   
   ``log_level=debug`` will output detailed logging info per steps; whereas ``log_level=info`` only output log at the end of each epoch. 
+  For performance mode, we would suggest using error mode to suppress unnecessory logs. 
 
 dataset
 ------------------

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -356,19 +356,11 @@ output
      - The output folder name.
    * - log_file
      - dlio.log
-     - log file name  
-   * - log_level
-     - "info"
-     - select the logging level [error|warning|info|debug]
+     - log file name
 
 .. note::
    
    If ``folder`` is not set (None), the output folder will be ```hydra_log/unet3d/$DATE-$TIME```. 
-
-.. note:: 
-  
-  ``log_level=debug`` will output detailed logging info per steps; whereas ``log_level=info`` only output log at the end of each epoch. 
-  For performance mode, we would suggest using error mode to suppress unnecessory logs. 
 
 profiling
 ------------------
@@ -397,3 +389,22 @@ The YAML files are stored in the `workload`_ folder.
 It then can be loaded by ```dlio_benchmark``` through hydra (https://hydra.cc/). This will override the default settings. One can override the configurations through command line (https://hydra.cc/docs/advanced/override_grammar/basic/).
 
 .. _workload: https://github.com/argonne-lcf/dlio_benchmark/tree/main/dlio_benchmark/configs/workload
+
+
+Environment variables
+============================================
+There are a few environment variables that controls and logging and profiling information. 
+
+
+   * - Variable name
+     - Default
+     - Description
+   * - DLIO_LOG_LEVEL
+     - warning
+     - Specifying the loging level [error|warning|info|debug]. If info is set, it will output the progress for each step. 
+   * - DFTRACER_ENABLE
+     - 0
+     - Enabling the dftracer profiling or not [0|1]
+   * - DFTRACER_INC_METADATA
+     - 0
+     - Whether to include the meta data in the trace output or not [0|1] 

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -100,20 +100,12 @@ workflow
    * - profiling
      - False
      - whether to perform profiling
-   * - log_level
-     - "info"
-     - select the logging level [error|warn|info|debug|]
 
 .. note:: 
 
  ``evaluation``, ``checkpoint``, and ``profiling`` have depency on ``train``. If ``train`` is set to be ```False```, ``evaluation``, ``checkpoint``, ``profiling`` will be reset to ```False``` automatically. 
 
   Even though ``generate_data`` and ``train`` can be performed together in one job, we suggest to perform them seperately to eliminate potential caching effect. One can generate the data first by running DLIO with ```generate_data=True``` and ```train=False```, and then run training benchmark with ```generate_data=False``` and ```train=True```. 
-
-.. note:: 
-  
-  ``log_level=debug`` will output detailed logging info per steps; whereas ``log_level=info`` only output log at the end of each epoch. 
-  For performance mode, we would suggest using error mode to suppress unnecessory logs. 
 
 dataset
 ------------------
@@ -365,10 +357,18 @@ output
    * - log_file
      - dlio.log
      - log file name  
+   * - log_level
+     - "info"
+     - select the logging level [error|warning|info|debug]
 
 .. note::
    
    If ``folder`` is not set (None), the output folder will be ```hydra_log/unet3d/$DATE-$TIME```. 
+
+.. note:: 
+  
+  ``log_level=debug`` will output detailed logging info per steps; whereas ``log_level=info`` only output log at the end of each epoch. 
+  For performance mode, we would suggest using error mode to suppress unnecessory logs. 
 
 profiling
 ------------------

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -100,12 +100,19 @@ workflow
    * - profiling
      - False
      - whether to perform profiling
+   * - log_level
+     - "info"
+     - select the logging level [warn|info|debug]
 
 .. note:: 
 
  ``evaluation``, ``checkpoint``, and ``profiling`` have depency on ``train``. If ``train`` is set to be ```False```, ``evaluation``, ``checkpoint``, ``profiling`` will be reset to ```False``` automatically. 
 
   Even though ``generate_data`` and ``train`` can be performed together in one job, we suggest to perform them seperately to eliminate potential caching effect. One can generate the data first by running DLIO with ```generate_data=True``` and ```train=False```, and then run training benchmark with ```generate_data=False``` and ```train=True```. 
+
+.. note:: 
+  
+  ``log_level=debug`` will output detailed logging info per steps; whereas ``log_level=info`` only output log at the end of each epoch. 
 
 dataset
 ------------------

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -219,7 +219,6 @@ BERT: Natural Language Processing Model
     workflow:
         generate_data: False
         train: True
-        debug: False
         checkpoint: True
     
     dataset: 

--- a/docs/source/profiling.rst
+++ b/docs/source/profiling.rst
@@ -26,7 +26,6 @@ The output is
     do_eval: False
     batch_size_eval: 1
     do_checkpoint: True
-    debug: False
     name: unet3d
     2023-06-27 21:38:00 Generating Report
     2023-06-27 21:38:00 Calculating Loading and Processing Times


### PR DESCRIPTION
In this PR, we changed the per step output from info to debug to reduce the logging overhead. 

We added support for changing logging level through environment variable `DLIO_LOG_LEVEL` which can be set to be error, warning, output, info, debug. By default we set as output. 

All the per-step log is put >= info level. The output level only contains per epoch logs. With this, the log file size is significantly reduced. 

In the debug level, the log format contains source file and line number, while other levels do not. 
