### PR TITLE
fix misleading generator message

### DIFF
--- a/dlio_benchmark/data_generator/hdf5_generator.py
+++ b/dlio_benchmark/data_generator/hdf5_generator.py
@@ -64,7 +64,7 @@ class HDF5Generator(DataGenerator):
             dim2 = dim[2*i+1]
             records = np.random.randint(255, size=(dim1, dim2, self.num_samples), dtype=np.uint8)
             out_path_spec = self.storage.get_uri(self._file_list[i])
-            progress(i+1, self.total_files_to_generate, "Generating NPZ Data")
+            progress(i+1, self.total_files_to_generate, "Generating HDF5 Data")
             hf = h5py.File(out_path_spec, 'w')
             hf.create_dataset('records', (self.num_samples, dim1, dim2), chunks=chunks, compression=compression,
                                     compression_opts=compression_level, dtype=np.uint8, data=records)


### PR DESCRIPTION
Hi @zhenghh04 and @hariharan-devarajan,

The current message says `Generating NPZ data` when it should say `Generating HDF5 data`. 
This can be misleading for users.