### PR TITLE
Fix wrong configuration for hdf5 chunking

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -155,7 +155,7 @@ dataset
    * - compression_level
      - 4
      - level of compression for gzip
-   * - chunking
+   * - enable_chunking
      - False
      - whether to use chunking to store hdf5. 
    * - chunk_size


### PR DESCRIPTION
The documentation says use `chunking` for HDF5 data creation but the code uses `enable_chunking`