### PR TITLE
fix wrong tracing location of fetch data

### DIFF
--- a/dlio_benchmark/data_loader/native_dali_data_loader.py
+++ b/dlio_benchmark/data_loader/native_dali_data_loader.py
@@ -60,7 +60,9 @@ class NativeDaliDataLoader(BaseDataLoader):
             pipeline.reset()
         for step in range(num_samples // batch_size):
             try:
-                for batch in self._dataset:
+                # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
+                #       `dlp.iter(self._dataset, name=self.next.__qualname__)`
+                for batch in dlp.iter(self._dataset):
                     logging.debug(f"{utcnow()} Creating {len(batch)} batches by {self._args.my_rank} rank ")
                     yield batch
             except StopIteration:

--- a/dlio_benchmark/data_loader/tf_data_loader.py
+++ b/dlio_benchmark/data_loader/tf_data_loader.py
@@ -100,7 +100,9 @@ class TFDataLoader(BaseDataLoader):
     @dlp.log
     def next(self):
         super().next()
-        for batch in self._dataset:
+        # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
+        #       `dlp.iter(self._dataset, name=self.next.__qualname__)`
+        for batch in dlp.iter(self._dataset):
             yield batch
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)

--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -166,7 +166,9 @@ class TorchDataLoader(BaseDataLoader):
         total = self._args.training_steps if self.dataset_type is DatasetType.TRAIN else self._args.eval_steps
         logging.debug(f"{utcnow()} Rank {self._args.my_rank} should read {total} batches")
         step = 1
-        for batch in self._dataset:
+        # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
+        #       `dlp.iter(self._dataset, name=self.next.__qualname__)`
+        for batch in dlp.iter(self._dataset):
             dlp.update(step = step)
             step += 1
             yield batch

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -224,7 +224,7 @@ class DLIOBenchmark(object):
         total = math.floor(self.num_samples * self.num_files_eval / self.batch_size_eval / self.comm_size)
         loader = self.framework.get_loader(DatasetType.VALID)
         t0 = time()
-        for batch in dlp.iter(loader.next()):
+        for batch in loader.next():
             self.stats.eval_batch_loaded(epoch, step, t0)
             eval_time = 0.0
             if self.eval_time > 0:
@@ -256,7 +256,7 @@ class DLIOBenchmark(object):
 
         loader = self.framework.get_loader(dataset_type=DatasetType.TRAIN)
         t0 = time()
-        for batch in dlp.iter(loader.next()):
+        for batch in loader.next():
             if overall_step > max_steps or ((self.total_training_steps > 0) and (overall_step > self.total_training_steps)):
                 if self.args.my_rank == 0:
                     logging.info(f"{utcnow()} Maximum number of steps reached")


### PR DESCRIPTION
Hi @zhenghh04 and @hariharan-devarajan,

If we use `dlp.iter` inside `main.py`, this does not reflect the real fetch data since the data is already fetched inside `DataLoader.next()`. Because of this, we ended up tracing the fetching of batch data that resides in the memory instead of tracing its fetching duration from filesystem or other sources.

This PR addresses the problem where we put `dlp.iter` inside the dataloader, as close as possible to the dataset itself.

For dali dataloader, I haven't implemented the fix since there is no visible iteration there (DALI uses `share_outputs`)

Note: @hariharan-devarajan when we bump the dftracer version, we should provide the name of the `dlp.iter`.
I left a note to change `dlp.iter` to `dlp.iter(..., name=self.next.__qualname__)`