### PR TITLE
enable option to disable pin_memory in pytorch

### DIFF
--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -143,7 +143,7 @@ class TorchDataLoader(BaseDataLoader):
                                        batch_size=self.batch_size,
                                        sampler=sampler,
                                        num_workers=self._args.read_threads,
-                                       pin_memory=True,
+                                       pin_memory=self._args.pin_memory,
                                        drop_last=True,
                                        worker_init_fn=dataset.worker_init, 
                                        **kwargs)
@@ -152,7 +152,7 @@ class TorchDataLoader(BaseDataLoader):
                                        batch_size=self.batch_size,
                                        sampler=sampler,
                                        num_workers=self._args.read_threads,
-                                       pin_memory=True,
+                                       pin_memory=self._args.pin_memory,
                                        drop_last=True,
                                        worker_init_fn=dataset.worker_init,
                                        **kwargs)  # 2 is the default value

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -118,6 +118,7 @@ class ConfigArguments:
     data_loader_sampler: DataLoaderSampler = None
     reader_classname: str = None
     multiprocessing_context: str = "fork"
+    pin_memory: bool = True
 
     # derived fields
     required_samples: int = 1
@@ -521,6 +522,8 @@ def LoadConfig(args, config):
             args.preprocess_time = reader['preprocess_time']
         if 'preprocess_time_stdev' in reader:
             args.preprocess_time_stdev = reader['preprocess_time_stdev']
+        if 'pin_memory' in reader:
+            args.pin_memory = reader['pin_memory']
 
     # training relevant setting
     if 'train' in config:

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -201,6 +201,9 @@ reader
    * - read_threads* 
      - 1
      - number of threads to load the data (for tensorflow and pytorch data loader)
+   * - pin_memory
+     - True
+     - whether to pin the memory for pytorch data loader
    * - computation_threads
      - 1
      - number of threads to preprocess the data


### PR DESCRIPTION
Hi @zhenghh04 and @hariharan-devarajan,

This PR gives us option to disable pin memory in pytorch dataloader.
I encountered error while emulating stormer when we increase the prefetch factor since the memory is being reserved and cannot be released until the dataloader is finished.
Also, pin_memory is beneficial for GPU memory pinning which we do not use at all for DLIO [1, 2]

I set the default to True for backward compatibility, let me know if I should put `pin_memory=False` as default in the configuration.

Reference:
[1] https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html
[2] https://discuss.pytorch.org/t/when-to-set-pin-memory-to-true/19723/19