### PR TITLE
Change `max` to `abs` for preprocess time

### DIFF
--- a/dlio_benchmark/reader/reader_handler.py
+++ b/dlio_benchmark/reader/reader_handler.py
@@ -60,9 +60,9 @@ class FormatReader(ABC):
 
     @dlp.log
     def preprocess(self, a=None):
-        if self._args.preprocess_time != 0. or self._args.preprocess_time_stdev != 0.:
+        if self._args.preprocess_time > 0. or self._args.preprocess_time_stdev > 0.:
             t = np.random.normal(self._args.preprocess_time, self._args.preprocess_time_stdev)
-            sleep(max(t, 0.0))
+            sleep(abs(t))
         return a
     @abstractmethod
     def open(self, filename):


### PR DESCRIPTION
Hi @zhenghh04 and @hariharan-devarajan,

This PR addresses the problem where `random.normal` result can be negative.
if we do `max(t, 0)` then we will reduce the variance of preprocess time when the generated value is negative. 

It is better to use `abs` in this case.

At the same time, I add strict comparison to make sure user does not give negative value while specifying `preprocess_time` or `preprocess_time_stdev` in the config.