### PR TITLE
upgrade pydftracer package

### DIFF
--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -70,7 +70,7 @@ class DLIOBenchmark(object):
             <li> local variables </li>
         </ul>
         """
-        global dftracer, dftracer_init, dftracer_finalize
+        global dftracer, dftracer_initialize, dftracer_finalize
 
         t0 = time()
         self.args = ConfigArguments.get_instance()
@@ -351,7 +351,7 @@ class DLIOBenchmark(object):
         It finalizes the dataset once training is completed.
         """
 
-        global dftracer, dftracer_init, dftracer_finalize
+        global dftracer, dftracer_initialize, dftracer_finalize
 
         self.comm.barrier()
         self.checkpointing_mechanism.finalize()
@@ -385,12 +385,12 @@ def run_benchmark(cfg: DictConfig):
     benchmark.run()
     benchmark.finalize()
 
-def set_dftracer_init(status):
-    global dftracer, dftracer_init, dftracer_finalize
+def set_dftracer_initialize(status):
+    global dftracer, dftracer_initialize, dftracer_finalize
     dftracer_initialize = status
 
 def set_dftracer_finalize(status):
-    global dftracer, dftracer_init, dftracer_finalize
+    global dftracer, dftracer_initialize, dftracer_finalize
     dftracer_finalize = status
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ nvidia-dali-cuda110>=1.34.0
 omegaconf~=2.2.0
 pandas~=1.5.1
 psutil~=5.9.8
-pydftracer==1.0.6
+pydftracer==1.0.8
 pytest
 tensorflow>=2.11.0
 torch>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ nvidia-dali-cuda110>=1.34.0
 omegaconf~=2.2.0
 pandas~=1.5.1
 psutil~=5.9.8
-pydftracer==1.0.2
+pydftracer==1.0.6
 pytest
 tensorflow>=2.11.0
 torch>=2.2.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ core_deps = [
     "omegaconf>=2.2.0",
     "pandas>=1.5.1",
     "psutil>=5.9.8",
-    "pydftracer==1.0.2",
+    "pydftracer==1.0.6",
 ]
 x86_deps = [
     f"hydra-core>={HYDRA_VERSION}",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ core_deps = [
     "omegaconf>=2.2.0",
     "pandas>=1.5.1",
     "psutil>=5.9.8",
-    "pydftracer==1.0.6",
+    "pydftracer==1.0.8",
 ]
 x86_deps = [
     f"hydra-core>={HYDRA_VERSION}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+# HACK: to fix the reinitialization problem
+def pytest_configure(config):
+    config.is_dftracer_initialized = False

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -117,7 +117,7 @@ def test_gen_data(fmt, framework) -> None:
         clean()
     finalize()
 
-@pytest.mark.timeout(120, method="thread")
+@pytest.mark.timeout(180, method="thread")
 def test_subset() -> None:
     init()
     clean()

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -135,7 +135,7 @@ def test_subset() -> None:
                             '++workload.dataset.num_files_train=8', \
                             '++workload.train.computation_time=0.01'])
         benchmark=run_benchmark(cfg, verify=True)
-    clean()
+        clean()
     finalize()
 
 @pytest.mark.timeout(60, method="thread")

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -47,8 +47,9 @@ import glob
 def init():
     DLIOMPI.get_instance().initialize()
 
-def finalize():
-    # DLIOMPI.get_instance().finalize()
+def finalize(cleanup=False):
+    if cleanup:
+        DLIOMPI.get_instance().finalize()
     pass
 
 def clean(storage_root="./") -> None:
@@ -135,8 +136,8 @@ def test_subset() -> None:
                             '++workload.dataset.num_files_train=8', \
                             '++workload.train.computation_time=0.01'])
         benchmark=run_benchmark(cfg, verify=True)
-        clean()
-    finalize()
+    clean()
+    finalize(cleanup=True)
 
 @pytest.mark.timeout(60, method="thread")
 @pytest.mark.parametrize("fmt, framework", [("png", "tensorflow"), ("npz", "tensorflow"),

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -117,7 +117,7 @@ def test_gen_data(fmt, framework) -> None:
         clean()
     finalize()
 
-@pytest.mark.timeout(60, method="thread")
+@pytest.mark.timeout(120, method="thread")
 def test_subset() -> None:
     init()
     clean()


### PR DESCRIPTION
Hi @zhenghh04 and @hariharan-devarajan,

This PR will update pydftracer package from `1.0.2` to `1.0.6`.

Note that pydftracer package `1.0.6` still does not include the new API of `dlp.iter(self, func, name, iter_name)` that is needed for [torch data loader](https://github.com/argonne-lcf/dlio_benchmark/blob/main/dlio_benchmark/data_loader/torch_data_loader.py#L169) but it is not a big of a deal for now.

Thanks!