### PR TITLE
docker: use pip install to match readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,5 @@ RUN apt-get update && \
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m venv /workspace/venv
 ENV PATH="/workspace/venv/bin:$PATH"
-RUN python3 -m pip install pybind11 
-RUN python setup.py build
-RUN python setup.py install
-
-
-
+RUN pip install pybind11 
+RUN pip install .


### PR DESCRIPTION
this also fixes docker build break with nvidia dali and fixes #243

[README.md](https://github.com/argonne-lcf/dlio_benchmark/blob/main/README.md#bare-metal-installation) says:
```
git clone https://github.com/argonne-lcf/dlio_benchmark
cd dlio_benchmark/
pip install .
dlio_benchmark ++workload.workflow.generate_data=True
```
also [ci.yml](https://github.com/argonne-lcf/dlio_benchmark/blob/main/.github/workflows/ci.yml#L65) doing
```
      - name: Install DLIO via setup.py
        if: matrix.venv == 'via-setup' && steps.cache-modules.outputs.cache-hit != 'true'
        run: |
          echo "venv: ${VENV_PATH} - gcc: $CC"
          python -m venv ${VENV_PATH}
          source ${VENV_PATH}/bin/activate
          pip install --upgrade pip
          pip install .[test]
```
