### PR TITLE
docs: small readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ docker run -t dlio dlio_benchmark ++workload.workflow.generate_data=True
 
 You can also pull rebuilt container from docker hub (might not reflect the most recent change of the code): 
 ```bash
-docker docker.io/zhenghh04/dlio:latest
+docker pull docker.io/zhenghh04/dlio:latest
 docker run -t docker.io/zhenghh04/dlio:latest python ./dlio_benchmark/main.py ++workload.workflow.generate_data=True
 ```
 If your running on a different architecture, refer to the Dockerfile to build the dlio_benchmark container from scratch.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ docker run -t dlio dlio_benchmark ++workload.workflow.generate_data=True
 You can also pull rebuilt container from docker hub (might not reflect the most recent change of the code): 
 ```bash
 docker pull docker.io/zhenghh04/dlio:latest
-docker run -t docker.io/zhenghh04/dlio:latest python ./dlio_benchmark/main.py ++workload.workflow.generate_data=True
+docker run -t docker.io/zhenghh04/dlio:latest dlio_benchmark ++workload.workflow.generate_data=True
 ```
 If your running on a different architecture, refer to the Dockerfile to build the dlio_benchmark container from scratch.
 
 One can also run interactively inside the container
 ```bash
 docker run -t docker.io/zhenghh04/dlio:latest /bin/bash
-root@30358dd47935:/workspace/dlio$ python ./dlio_benchmark/main.py ++workload.workflow.generate_data=True
+root@30358dd47935:/workspace/dlio$ dlio_benchmark ++workload.workflow.generate_data=True
 ```
 
 ## PowerPC


### PR DESCRIPTION
- missing pull command for docker
- use python console scripts like in other examples instead of invoking python on script directly