### PR TITLE
Fix saving checkpoint print

### DIFF
--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -349,7 +349,7 @@ class StatsCounter(object):
         self.per_epoch_stats[epoch][f'save_ckpt{block}']['duration'] = float(duration.total_seconds())
         self.per_epoch_stats[epoch][f'save_ckpt{block}']['throughput'] = self.checkpoint_size / float(duration.total_seconds())
         if self.my_rank == 0:
-            logging.info(f"{ts} Finished saving checkpoint {block} for epoch {epoch} in {duration.total_seconds():.4f} s; Throughput: {self.per_epoch_stats[epoch][f'save_ckpt{block}']['throughput']:.4f} GB/s")
+            self.logger.output(f"{ts} Finished saving checkpoint {block} for epoch {epoch} in {duration.total_seconds():.4f} s; Throughput: {self.per_epoch_stats[epoch][f'save_ckpt{block}']['throughput']:.4f} GB/s")
 
     def start_load_ckpt(self, epoch, block, steps_taken):
         ts = utcnow()


### PR DESCRIPTION
The saving checkpoint throughput is not written in the output.

```bash
[OUTPUT] 2025-03-19T08:07:38.517824 Running DLIO [Checkpointing] with 1 process(es)
[OUTPUT] 2025-03-19T08:08:03.667616 Starting block 1
[OUTPUT] 2025-03-19T08:08:08.668186 Starting saving checkpoint 1 after total step 1 for epoch 1
[OUTPUT] 2025-03-19T08:10:43.522289 Starting block 2
[OUTPUT] 2025-03-19T08:10:48.522737 Starting saving checkpoint 2 after total step 2 for epoch 1
[OUTPUT] 2025-03-19T08:13:21.650821 Starting loading checkpoint 2 after total step 2 for epoch 1
[OUTPUT] 2025-03-19T08:16:29.693366 Finished loading checkpoint 2 for epoch 1 in 341.1706 s; Throughput: 0.2575 GB/s
[OUTPUT] 2025-03-19T08:16:29.699832 Starting block 3
```
This patch match the print that is used for loading checkpoint. 
```bash
[OUTPUT] 2025-03-19T09:21:48.328425 Running DLIO [Checkpointing] with 2 process(es)
[OUTPUT] 2025-03-19T09:22:03.218077 Starting block 1
[OUTPUT] 2025-03-19T09:22:08.218622 Starting saving checkpoint 1 after total step 1 for epoch 1
[OUTPUT] 2025-03-19T09:23:25.328675 Finished saving checkpoint 1 for epoch 1 in 77.1101 s; Throughput: 1.1394 GB/s
[OUTPUT] 2025-03-19T09:23:25.330494 Starting block 2
[OUTPUT] 2025-03-19T09:23:30.330860 Starting saving checkpoint 2 after total step 2 for epoch 1
[OUTPUT] 2025-03-19T09:24:51.308062 Finished saving checkpoint 2 for epoch 1 in 80.9772 s; Throughput: 1.0850 GB/s
[OUTPUT] 2025-03-19T09:24:51.309484 Starting loading checkpoint 2 after total step 2 for epoch 1
[OUTPUT] 2025-03-19T09:26:10.878958 Finished loading checkpoint 2 for epoch 1 in 160.5481 s; Throughput: 0.5472 GB/s
[OUTPUT] 2025-03-19T09:26:10.892972 Starting block 3
```
