### PR TITLE
Refactor: move pydftracer dependency to extras for better management

### DIFF
--- a/dlio_benchmark/configs/workload/dlrm.yaml
+++ b/dlio_benchmark/configs/workload/dlrm.yaml
@@ -12,10 +12,8 @@ dataset:
   format: indexed_binary
   num_files_train: 1
   num_files_eval: 1
-  num_samples_per_file: 4195198976
+  num_samples_per_file: 2048437
   record_length_bytes: 671088640
-  keep_files: True
-  eval_num_samples_per_file: 91681240
 
 reader:
   data_loader: pytorch

--- a/dlio_benchmark/configs/workload/dlrm.yaml
+++ b/dlio_benchmark/configs/workload/dlrm.yaml
@@ -6,7 +6,7 @@ framework: pytorch
 workflow:
   generate_data: False
   train: True
-  do_eval: True
+  do_eval: False
 
 dataset:
   data_folder: data/dlrm
@@ -27,9 +27,3 @@ reader:
 train:
   epochs: 1
   computation_time: 0.064296
-  total_training_steps: 32768
-  total_eval_steps: 2048
-
-evaluation:
-  eval_time: 0.0843
-  steps_between_evals: 16384

--- a/dlio_benchmark/configs/workload/dlrm.yaml
+++ b/dlio_benchmark/configs/workload/dlrm.yaml
@@ -6,7 +6,6 @@ framework: pytorch
 workflow:
   generate_data: False
   train: True
-  do_eval: False
 
 dataset:
   data_folder: data/dlrm
@@ -14,14 +13,13 @@ dataset:
   num_files_train: 1
   num_files_eval: 1
   num_samples_per_file: 4195198976
-  record_length_bytes: 327680
+  record_length_bytes: 671088640
   keep_files: True
   eval_num_samples_per_file: 91681240
 
 reader:
   data_loader: pytorch
-  batch_size: 2048
-  batch_size_eval: 16384
+  batch_size: 1
   sample_shuffle: random
 
 train:

--- a/dlio_benchmark/configs/workload/dlrm.yaml
+++ b/dlio_benchmark/configs/workload/dlrm.yaml
@@ -12,7 +12,7 @@ dataset:
   format: indexed_binary
   num_files_train: 1
   num_files_eval: 1
-  num_samples_per_file: 2048437
+  num_samples_per_file: 1024
   record_length_bytes: 671088640
 
 reader:

--- a/dlio_benchmark/configs/workload/megatron_deepspeed_LLNL.yaml
+++ b/dlio_benchmark/configs/workload/megatron_deepspeed_LLNL.yaml
@@ -35,6 +35,7 @@ reader:
 train:
   epochs: 3
   computation_time: 2.44 # 2.44 sec per step
+  total_training_steps: 5000
 
 checkpoint:
   checkpoint_folder: checkpoints/megatron-deepspeed

--- a/dlio_benchmark/configs/workload/megatron_deepspeed_LLNL.yaml
+++ b/dlio_benchmark/configs/workload/megatron_deepspeed_LLNL.yaml
@@ -8,7 +8,7 @@ model:
   parallelism: 
     pipeline: 8
     tensor: 4
-    zero_stage: 0
+    zero_stage: 1
   layer_parameters: [52583936, 209715200]
 
 framework: pytorch

--- a/dlio_benchmark/configs/workload/megatron_deepspeed_LLNL.yaml
+++ b/dlio_benchmark/configs/workload/megatron_deepspeed_LLNL.yaml
@@ -35,7 +35,7 @@ reader:
 train:
   epochs: 3
   computation_time: 2.44 # 2.44 sec per step
-  total_training_steps: 5000
+  total_training_steps: 1000
 
 checkpoint:
   checkpoint_folder: checkpoints/megatron-deepspeed

--- a/dlio_benchmark/data_generator/indexed_binary_generator.py
+++ b/dlio_benchmark/data_generator/indexed_binary_generator.py
@@ -93,7 +93,7 @@ class IndexedBinaryGenerator(DataGenerator):
                     self.logger.info(f"{utcnow()} Starting Sample generation. ")
                 
                 fh = MPI.File.Open(comm, out_path_spec, amode)
-                samples_per_loop = int(MB * 16 / sample_size)
+                samples_per_loop = int(MB * 1024 / sample_size)
 
                 for sample_index in range(self.my_rank*samples_per_rank, samples_per_rank*(self.my_rank+1), samples_per_loop):
                     #self.logger.info(f"{utcnow()} rank {self.my_rank} writing {sample_index} * {samples_per_loop} for {samples_per_rank} samples")

--- a/dlio_benchmark/data_generator/indexed_binary_generator.py
+++ b/dlio_benchmark/data_generator/indexed_binary_generator.py
@@ -50,7 +50,7 @@ class IndexedBinaryGenerator(DataGenerator):
         """
         super().generate()
         np.random.seed(10)
-        MB=1048576
+        GB=1024*1024*1024
         samples_processed = 0
         total_samples = self.total_files_to_generate * self.num_samples
         dim = self.get_dimension(self.total_files_to_generate)
@@ -74,7 +74,7 @@ class IndexedBinaryGenerator(DataGenerator):
                 fh_off = MPI.File.Open(comm, out_path_spec_off_idx, amode)
                 fh_sz = MPI.File.Open(comm, out_path_spec_sz_idx, amode)
                 off_type = np.uint64
-                elements_per_loop = min(int(MB / np.dtype(off_type).itemsize), samples_per_rank)
+                elements_per_loop = min(int(GB / np.dtype(off_type).itemsize), samples_per_rank)
                 offsets_processed=0
                 for element_index in range(self.my_rank*samples_per_rank, samples_per_rank*(self.my_rank+1), elements_per_loop):
                     offsets = np.array(range(self.my_rank * elements_per_loop * sample_size, 
@@ -93,11 +93,12 @@ class IndexedBinaryGenerator(DataGenerator):
                     self.logger.info(f"{utcnow()} Starting Sample generation. ")
                 
                 fh = MPI.File.Open(comm, out_path_spec, amode)
-                samples_per_loop = int(MB * 1024 / sample_size)
+                samples_per_loop = int(GB / sample_size)
+                
+                records = np.random.randint(255, size=sample_size*samples_per_loop, dtype=np.uint8)
 
                 for sample_index in range(self.my_rank*samples_per_rank, samples_per_rank*(self.my_rank+1), samples_per_loop):
                     #self.logger.info(f"{utcnow()} rank {self.my_rank} writing {sample_index} * {samples_per_loop} for {samples_per_rank} samples")
-                    records = records = np.random.randint(255, size=sample_size*samples_per_loop, dtype=np.uint8)
                     offset = sample_index * sample_size
                     fh.Write_at_all(offset, records)
                     samples_processed += samples_per_loop

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -437,7 +437,20 @@ def main() -> None:
     run_benchmark()
     DLIOMPI.get_instance().finalize()
 
-
+@hydra.main(version_base=None, config_path="configs", config_name="config")
+def query_config(cfg: DictConfig):
+    config = cfg['workload']
+    value = None
+    if "query" in config["workflow"]:
+        key = config["workflow"]["query"]
+        keys = key.split(".")
+        for k in keys:
+            if value:
+                value = value[k]
+            else:
+                value = config[k]
+    print(value) if value else print("None")
+    
 if __name__ == '__main__':
     main()
     exit(0)

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -39,7 +39,7 @@ from dlio_benchmark.utils.utility import utcnow, measure_performance, get_trace_
 from omegaconf import DictConfig, OmegaConf
 from dlio_benchmark.utils.statscounter import StatsCounter
 from hydra.core.config_store import ConfigStore
-from dlio_benchmark.utils.config import LoadConfig, ConfigArguments
+from dlio_benchmark.utils.config import LoadConfig, ConfigArguments, GetConfig
 from dlio_benchmark.common.enumerations import Profiler, DatasetType, StorageType, MetadataType, FormatType
 from dlio_benchmark.profiler.profiler_factory import ProfilerFactory
 from dlio_benchmark.framework.framework_factory import FrameworkFactory
@@ -439,17 +439,17 @@ def main() -> None:
 
 @hydra.main(version_base=None, config_path="configs", config_name="config")
 def query_config(cfg: DictConfig):
+    DLIOMPI.get_instance().initialize()
     config = cfg['workload']
+    
     value = None
     if "query" in config["workflow"]:
         key = config["workflow"]["query"]
-        keys = key.split(".")
-        for k in keys:
-            if value:
-                value = value[k]
-            else:
-                value = config[k]
+        args = ConfigArguments.get_instance()
+        LoadConfig(args, config)
+        value = GetConfig(args, key)
     print(value) if value else print("None")
+    DLIOMPI.get_instance().finalize()
     
 if __name__ == '__main__':
     main()

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -225,8 +225,11 @@ class DLIOBenchmark(object):
                 file_list_eval = file_list_eval[:self.num_files_eval]
         self.args.derive_configurations(file_list_train, file_list_eval)
         self.args.validate()
-        self.checkpointing_mechanism = CheckpointingFactory().get_mechanism(self.args.checkpoint_mechanism)
-        self.stats.checkpoint_size = self.checkpointing_mechanism.checkpoint_size    
+        self.checkpointing_mechanism = None
+        self.stats.checkpoint_size = 0
+        if (not self.generate_only) and (not self.args.checkpoint_only):
+            self.checkpointing_mechanism = CheckpointingFactory().get_mechanism(self.args.checkpoint_mechanism)
+            self.stats.checkpoint_size = self.checkpointing_mechanism.checkpoint_size    
         self.comm.barrier()
 
     @dlp.log

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -393,7 +393,8 @@ class DLIOBenchmark(object):
         global dftracer, dftracer_initialize, dftracer_finalize
 
         self.comm.barrier()
-        self.checkpointing_mechanism.finalize()
+        if self.checkpointing_mechanism:
+            self.checkpointing_mechanism.finalize()
         if not self.generate_only:
             if self.do_profiling:
                 self.profiler.stop()

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -509,7 +509,7 @@ def GetConfig(args, key):
 
     # data reader
     reader = None
-    if len(keys) > 1 and keys[0] == "data_reader" and keys[0] == "reader":
+    if len(keys) > 1 and (keys[0] == "data_reader" or keys[0] == "reader"):
         if keys[1] == "dont_use_mmap":
             value = args.dont_use_mmap
         elif keys[1] == "reader_classname":

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -459,6 +459,223 @@ class ConfigArguments:
             if self.eval_sample_index_sum != global_eval_sample_sum:
                 raise Exception(f"Sharding of eval samples are missing samples got {global_eval_sample_sum} but expected {self.eval_sample_index_sum}")
 
+def GetConfig(args, key):
+    keys = key.split(".")
+    value = None
+    if len(keys) > 0 and keys[0] == "framework":
+        value = args.framework
+    
+    if len(keys) > 1 and keys[0] == "storage":
+        if keys[1] == "storage_type":
+            value = args.storage_type
+        elif keys[1] == "storage_root":
+            value = args.storage_root
+    
+    if len(keys) > 1 and keys[0] == "dataset":
+        if keys[1] == "record_length_bytes":
+            value = args.record_length
+        elif keys[1] == "record_length_byte_stdev":
+            value = args.record_length_stdev
+        elif keys[1] == "record_length_bytes_resize":
+            value = args.record_length_resize
+        elif keys[1] == "num_files_train":
+            value = args.num_files_train
+        elif keys[1] == "num_files_eval":
+            value = args.num_files_eval
+        elif keys[1] == "generation_buffer_size":
+            value = args.generation_buffer_size
+        elif keys[1] == "num_samples_per_file":
+            value = args.num_samples_per_file
+        elif keys[1] == "data_folder":
+            value = args.data_folder
+        elif keys[1] == "num_subfolders_train":
+            value = args.num_subfolders_train
+        elif keys[1] == "num_subfolders_eval":
+            value = args.num_subfolders_eval
+        elif keys[1] == "enable_chunking":
+            value = args.enable_chunking
+        elif keys[1] == "chunk_size":
+            value = args.chunk_size
+        elif keys[1] == "compression":
+            value = args.compression
+        elif keys[1] == "compression_level":
+            value = args.compression_level
+        elif keys[1] == "file_prefix":
+            value = args.file_prefix
+        elif keys[1] == "format":
+            value = args.format
+        elif keys[1] == "keep_files":
+            value = args.keep_files
+
+    # data reader
+    reader = None
+    if len(keys) > 0 and keys[0] == "data_reader":
+        reader = config['data_reader']
+    elif len(keys) > 0 and keys[0] == "reader":
+        reader = config['reader']
+    if reader is not None:
+        if len(keys) > 1 and keys[1] == "dont_use_mmap":
+            value = args.dont_use_mmap
+        elif len(keys) > 1 and keys[1] == "reader_classname":
+            value = args.reader_classname
+        elif len(keys) > 1 and keys[1] == "multiprocessing_context":
+            value = args.multiprocessing_context
+        elif len(keys) > 1 and keys[1] == "data_loader":
+            value = args.data_loader
+        elif len(keys) > 1 and keys[1] == "data_loader_classname":
+            value = args.data_loader_classname
+        elif len(keys) > 1 and keys[1] == "data_loader_sampler":
+            value = args.data_loader_sampler
+        elif len(keys) > 1 and keys[1] == "read_threads":
+            value = args.read_threads
+        elif len(keys) > 1 and keys[1] == "computation_threads":
+            value = args.computation_threads
+        elif len(keys) > 1 and keys[1] == "batch_size":
+            value = args.batch_size
+        elif len(keys) > 1 and keys[1] == "batch_size_eval":
+            value = args.batch_size_eval
+        elif len(keys) > 1 and keys[1] == "prefetch_size":
+            value = args.prefetch_size
+        elif len(keys) > 1 and keys[1] == "file_shuffle":
+            value = args.file_shuffle
+        elif len(keys) > 1 and keys[1] == "file_access":
+            value = args.file_access
+        elif len(keys) > 1 and keys[1] == "shuffle_size":
+            value = args.shuffle_size
+        elif len(keys) > 1 and keys[1] == "sample_shuffle":
+            value = args.sample_shuffle
+        elif len(keys) > 1 and keys[1] == "read_type":
+            value = args.read_type
+        elif len(keys) > 1 and keys[1] == "transfer_size":
+            value = args.transfer_size
+        elif len(keys) > 1 and keys[1] == "preprocess_time":
+            value = args.preprocess_time
+        elif len(keys) > 1 and keys[1] == "preprocess_time_stdev":
+            value = args.preprocess_time.get("stdev", None)
+        elif len(keys) > 1 and keys[1] == "pin_memory":
+            value = args.pin_memory
+
+    # training relevant setting
+    if len(keys) > 1 and keys[0] == "train":
+        if keys[1] == "epochs":
+            value = args.epochs
+        elif keys[1] == "total_training_steps":
+            value = args.total_training_steps
+        elif keys[1] == "seed_change_epoch":
+            value = args.seed_change_epoch
+        elif keys[1] == "computation_time":
+            value = args.computation_time
+        elif keys[1] == "computation_time_stdev":
+            value = args.computation_time.get("stdev", None)
+        elif keys[1] == "seed":
+            value = args.seed
+
+    if len(keys) > 1 and keys[0] == "evaluation":
+        if keys[1] == "eval_time":
+            value = args.eval_time
+        elif keys[1] == "eval_time_stdev":
+            value = args.eval_time.get("stdev", None)
+        elif keys[1] == "eval_after_epoch":
+            value = args.eval_after_epoch
+        elif keys[1] == "epochs_between_evals":
+            value = args.epochs_between_evals
+
+    if len(keys) > 1 and keys[0] == "checkpoint":
+        if keys[1] == "checkpoint_folder":
+            value = args.checkpoint_folder
+        elif keys[1] == "checkpoint_after_epoch":
+            value = args.checkpoint_after_epoch
+        elif keys[1] == "epochs_between_checkpoints":
+            value = args.epochs_between_checkpoints
+        elif keys[1] == "steps_between_checkpoints":
+            value = args.steps_between_checkpoints
+        elif keys[1] == "type":
+            value = args.checkpoint_type
+        elif keys[1] == "checkpoint_mechanism_classname":
+            value = args.checkpoint_mechanism_classname
+        elif keys[1] == "fsync":
+            value = args.checkpoint_fsync
+        elif keys[1] == "time_between_checkpoints":
+            value = args.time_between_checkpoints
+        elif keys[1] == "num_checkpoints":
+            value = args.num_checkpoints
+        elif keys[1] == "load_rank_shift":
+            value = args.checkpoint_load_rank_shift
+        elif keys[1] == "recovery_after_steps":
+            value = args.checkpoint_recovery_after_steps
+
+    if len(keys) > 1 and keys[0] == "model":
+        if keys[1] == "name":
+            value = args.model
+        elif keys[1] == "type":
+            value = args.model_type
+        elif keys[1] == "model_size_bytes":
+            value = args.model_size
+        elif keys[1] == "optimization_groups":
+            value = args.optimization_groups
+        elif keys[1] == "num_layers":
+            value = args.num_layers
+        elif keys[1] == "layer_parameters":
+            value = args.layer_parameters
+        elif keys[1] == "model_datatype":
+            value = args.model_datatype
+        elif keys[1] == "optimizer_datatype":
+            value = args.optimizer_datatype
+
+        if len(keys) > 2 and keys[1] == "parallelism":
+            if keys[2] == "tensor":
+                value = args.tensor_parallelism
+            elif keys[2] == "pipeline":
+                value = args.pipeline_parallelism
+            elif keys[2] == "zero_stage":
+                value = args.zero_stage
+
+        if len(keys) > 2 and keys[1] == "transformer":
+            if keys[2] == "vocab_size":
+                value = args.vocab_size
+            elif keys[2] == "hidden_size":
+                value = args.hidden_size
+            elif keys[2] == "ffn_hidden_size":
+                value = args.ffn_hidden_size
+            elif keys[2] == "num_attention_heads":
+                value = args.num_attention_heads
+            elif keys[2] == "num_kv_heads":
+                value = args.num_kv_heads
+            
+    if len(keys) > 1 and keys[0] == "output":
+        if keys[1] == "folder":
+            value = args.output_folder
+        elif keys[1] == "log_file":
+            value = args.log_file
+        elif keys[1] == "metric":
+            if len(keys) > 2 and keys[2] == "exclude_start_steps":
+                value = args.metric_exclude_start_steps
+            elif len(keys) > 2 and keys[2] == "exclude_end_steps":
+                value = args.metric_exclude_end_steps
+
+    if len(keys) > 1 and keys[0] == "workflow":
+        if keys[1] == "train":
+            value = args.do_train
+        elif keys[1] == "generate_data":
+            value = args.generate_data
+        elif keys[1] == "evaluation":
+            value = args.do_eval
+        elif keys[1] == "checkpoint":
+            value = args.do_checkpoint
+        elif keys[1] == "profiling":
+            value = args.do_profiling
+
+    if len(keys) > 0 and keys[0] == "profiling":
+        if len(keys) > 1 and keys[1] == "profiler":
+            value = args.profiler
+        elif len(keys) > 1 and keys[1] == "iostat_devices":
+            value = args.iostat_devices
+
+    if len(keys) > 0 and keys[0] == "metric":
+        if len(keys) > 1 and keys[1] == "au":
+            value = args.au
+    return str(value) if value else None
+
 def LoadConfig(args, config):
     '''
     Override the args by a system config (typically loaded from a YAML file)

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -227,7 +227,7 @@ class ConfigArguments:
         if DFTRACER_ENABLE:
             dlp_trace = get_trace_name(self.output_folder, use_pid)
             if DLIOMPI.get_instance().rank() == 0:
-                self.logger.info(f"{utcnow()} Profiling DLIO {dlp_trace}")
+                self.logger.output(f"{utcnow()} Profiling DLIO {dlp_trace}")
             return PerfTrace.initialize_log(logfile=dlp_trace,
                                                    data_dir=f"{os.path.abspath(self.data_folder)}:"
                                                             f"{self.data_folder}:./{self.data_folder}:"

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -545,7 +545,7 @@ def GetConfig(args, key):
         elif keys[1] == "transfer_size":
             value = args.transfer_size
         elif keys[1] == "preprocess_time":
-            value = args.preprocess_time
+            value = args.preprocess_time.get("mean", 0)
         elif keys[1] == "preprocess_time_stdev":
             value = args.preprocess_time.get("stdev", None)
         elif keys[1] == "pin_memory":
@@ -560,7 +560,7 @@ def GetConfig(args, key):
         elif keys[1] == "seed_change_epoch":
             value = args.seed_change_epoch
         elif keys[1] == "computation_time":
-            value = args.computation_time
+            value = args.computation_time.get("mean", 0)
         elif keys[1] == "computation_time_stdev":
             value = args.computation_time.get("stdev", None)
         elif keys[1] == "seed":
@@ -568,7 +568,7 @@ def GetConfig(args, key):
 
     if len(keys) > 1 and keys[0] == "evaluation":
         if keys[1] == "eval_time":
-            value = args.eval_time
+            value = args.eval_time.get("mean", 0)
         elif keys[1] == "eval_time_stdev":
             value = args.eval_time.get("stdev", None)
         elif keys[1] == "eval_after_epoch":

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -509,50 +509,46 @@ def GetConfig(args, key):
 
     # data reader
     reader = None
-    if len(keys) > 0 and keys[0] == "data_reader":
-        reader = config['data_reader']
-    elif len(keys) > 0 and keys[0] == "reader":
-        reader = config['reader']
-    if reader is not None:
-        if len(keys) > 1 and keys[1] == "dont_use_mmap":
+    if len(keys) > 1 and keys[0] == "data_reader" and keys[0] == "reader":
+        if keys[1] == "dont_use_mmap":
             value = args.dont_use_mmap
-        elif len(keys) > 1 and keys[1] == "reader_classname":
+        elif keys[1] == "reader_classname":
             value = args.reader_classname
-        elif len(keys) > 1 and keys[1] == "multiprocessing_context":
+        elif keys[1] == "multiprocessing_context":
             value = args.multiprocessing_context
-        elif len(keys) > 1 and keys[1] == "data_loader":
+        elif keys[1] == "data_loader":
             value = args.data_loader
-        elif len(keys) > 1 and keys[1] == "data_loader_classname":
+        elif keys[1] == "data_loader_classname":
             value = args.data_loader_classname
-        elif len(keys) > 1 and keys[1] == "data_loader_sampler":
+        elif keys[1] == "data_loader_sampler":
             value = args.data_loader_sampler
-        elif len(keys) > 1 and keys[1] == "read_threads":
+        elif keys[1] == "read_threads":
             value = args.read_threads
-        elif len(keys) > 1 and keys[1] == "computation_threads":
+        elif keys[1] == "computation_threads":
             value = args.computation_threads
-        elif len(keys) > 1 and keys[1] == "batch_size":
+        elif keys[1] == "batch_size":
             value = args.batch_size
-        elif len(keys) > 1 and keys[1] == "batch_size_eval":
+        elif keys[1] == "batch_size_eval":
             value = args.batch_size_eval
-        elif len(keys) > 1 and keys[1] == "prefetch_size":
+        elif keys[1] == "prefetch_size":
             value = args.prefetch_size
-        elif len(keys) > 1 and keys[1] == "file_shuffle":
+        elif keys[1] == "file_shuffle":
             value = args.file_shuffle
-        elif len(keys) > 1 and keys[1] == "file_access":
+        elif keys[1] == "file_access":
             value = args.file_access
-        elif len(keys) > 1 and keys[1] == "shuffle_size":
+        elif keys[1] == "shuffle_size":
             value = args.shuffle_size
-        elif len(keys) > 1 and keys[1] == "sample_shuffle":
+        elif keys[1] == "sample_shuffle":
             value = args.sample_shuffle
-        elif len(keys) > 1 and keys[1] == "read_type":
+        elif keys[1] == "read_type":
             value = args.read_type
-        elif len(keys) > 1 and keys[1] == "transfer_size":
+        elif keys[1] == "transfer_size":
             value = args.transfer_size
-        elif len(keys) > 1 and keys[1] == "preprocess_time":
+        elif keys[1] == "preprocess_time":
             value = args.preprocess_time
-        elif len(keys) > 1 and keys[1] == "preprocess_time_stdev":
+        elif keys[1] == "preprocess_time_stdev":
             value = args.preprocess_time.get("stdev", None)
-        elif len(keys) > 1 and keys[1] == "pin_memory":
+        elif keys[1] == "pin_memory":
             value = args.pin_memory
 
     # training relevant setting

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ core_deps = [
     "omegaconf>=2.2.0",
     "pandas>=1.5.1",
     "psutil>=5.9.8",
-    "pydftracer==1.0.8",
 ]
 x86_deps = [
     f"hydra-core>={HYDRA_VERSION}",
@@ -40,6 +39,9 @@ else:
 
 extras = {
     "test": test_deps,
+    "dftracer": [
+        "pydftracer==1.0.8",
+    ],
 }
 
 here = pathlib.Path(__file__).parent.resolve()

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(
     entry_points={
         "console_scripts": [
             "dlio_benchmark = dlio_benchmark.main:main",
+            "dlio_benchmark_query = dlio_benchmark.main:query_config",
             "dlio_postprocessor = dlio_benchmark.postprocessor:main",
         ]
     },


### PR DESCRIPTION
Changes required to support CI support on HPC systems. I am building a CI on LC systems. This needs the following capabilities

- [x] ability to make dftracer optional. So that I can install any version I want.
- [x] fix configurations which are failing.