### PR TITLE
Reduce RAM Usage for checkpointing (zero1)

### DIFF
--- a/dlio_benchmark/checkpointing/base_checkpointing.py
+++ b/dlio_benchmark/checkpointing/base_checkpointing.py
@@ -99,13 +99,20 @@ class BaseCheckpointing(ABC):
                 for layer_index in range(start_layer, end_layer + 1):
                     self.layer_state[str(layer_index)] = layer_state  
             elif self.args.num_layers > 0:
-                self.layer_state = dict()
-                model_checkpoint_size = 0.0
-                for layer_index in range(start_layer, end_layer + 1):
-                    self.layer_state[str(layer_index)], size = self.get_layer_state(layer_index)
-                    model_checkpoint_size += size
-                if self.args.my_rank == 0:
-                    self.logger.info(f"{utcnow()} Layer states defined! {model_checkpoint_size/1024./1024./1024} GB per rank")
+                should_allocate_model_params = True
+
+                # Conditional check specifically for ZeRO Stage 1, non-DP-rank-0
+                if self.args.zero_stage == 1 and self.data_parallelism_rank != 0:
+                    should_allocate_model_params = False # Don't allocate if not DP rank 0 for ZeRO=1
+
+                if should_allocate_model_params:
+                    self.layer_state = dict()
+                    model_checkpoint_size = 0.0
+                    for layer_index in range(start_layer, end_layer + 1):
+                        self.layer_state[str(layer_index)], size = self.get_layer_state(layer_index)
+                        model_checkpoint_size += size
+                    if self.args.my_rank == 0:
+                        self.logger.info(f"{utcnow()} Layer states defined! {model_checkpoint_size/1024./1024./1024} GB per rank")
 
             # optimization state
             self.optimization_state = None
@@ -137,13 +144,10 @@ class BaseCheckpointing(ABC):
 
         model_checkpoint_size = self.comm.allreduce(model_checkpoint_size)/1024./1024./1024.
         optimizer_checkpoint_size = self.comm.allreduce(optimizer_checkpoint_size)/1024./1024./1024.
-        if self.args.zero_stage < 3:
-            num_data_parallel_instances = self.comm.size//self.model_parallelism
-            if num_data_parallel_instances > 0:
-                model_checkpoint_size /= num_data_parallel_instances
+
         if self.args.model_type != "transformer" and self.args.model_size > 0:
             model_checkpoint_size = self.args.model_size/1024./1024./1024.
-        
+
         self.checkpoint_size = model_checkpoint_size + optimizer_checkpoint_size
         if self.args.checkpoint_mode == CheckpointModeType.SUBSET:
             warning_message = f" (subset)"


### PR DESCRIPTION
With zero1, only the first DP saves the model parameters. There is no need to allocate these parameters on other DP.

The original RAM formula for zero1 was:
`ram = ((model_size/(TP*PP))+(optimizer_size/(TP*PP*DP)))*(TP*PP*DP)`
Which would scale badly with increased DP.

With the patch, this simplifies to:
`ram = model_size + optimizer_size`
Which is equal to zero3 RAM usage.

The reduction becomes more significant as DP increases. 
For example, a 70B model with 8TP, 4PP, and 4DP requires 1300GB without the patch, but only 910GB with it.

This is still not equivalent to zero3, since only the first DP saves the model parameters.
The RAM usage changed but the IO workload should be the same. 

Measured on a single node 70B: 8 (TP) x 4 (PP) x 4 (DP) = 128
Without the patch: 1.4TiB RAM usage (without accouting for pagecache)
With the patch: 1TiB usage
