### PR TITLE
Add hash consing optimization (checkpoint)

### DIFF
--- a/dlio_benchmark/checkpointing/pytorch_checkpointing.py
+++ b/dlio_benchmark/checkpointing/pytorch_checkpointing.py
@@ -60,11 +60,32 @@ class PyTorchCheckpointing(BaseCheckpointing):
         super().__init__("pt")
 
     @dlp.log
-    def get_tensor(self, length, datatype="int8"):
+    def get_tensor_length(self, tensor):
+        return tensor.numel()
+
+    @dlp.log
+    def get_tensor_dtype_str(self, tensor):
+        return self._map_dtype_to_str(tensor.dtype)
+
+    @dlp.log
+    def _map_dtype_to_str(self, dtype):
+        # Reverse mapping needed for pool key consistency
+        if dtype == torch.float32: return "fp32"
+        if dtype == torch.float16: return "fp16"
+        if dtype == torch.bfloat16: return "bf16"
+        if dtype == torch.int8: return "int8"
+        if dtype == torch.uint8: return "uint8"
+        if dtype == torch.float64: return "fp64"
+        # Add others as needed
+        self.logger.warning(f"Unmapped torch dtype: {dtype}")
+        return str(dtype) # Fallback
+
+    @dlp.log
+    def get_tensor_core(self, length, datatype="int8"):
         return torch.ones(length, dtype=get_torch_datatype(datatype))
 
     @dlp.log
-    def save_state(self, suffix, state, fsync = False):
+    def save_state_core(self, suffix, state, fsync = False):
         name = self.get_name(suffix)
         with open(name, "wb") as f:
             torch.save(state, f)

--- a/dlio_benchmark/checkpointing/tf_checkpointing.py
+++ b/dlio_benchmark/checkpointing/tf_checkpointing.py
@@ -58,11 +58,33 @@ class TFCheckpointing(BaseCheckpointing):
         super().__init__("pb")
 
     @dlp.log
-    def get_tensor(self, length, datatype="int8"):
+    def get_tensor_length(self, tensor):
+        # Returns the total number of elements as a Python integer
+        return tf.size(tensor).numpy()
+
+    @dlp.log
+    def get_tensor_dtype_str(self, tensor):
+        # Returns a string representation like "fp32"
+        return self._map_dtype_to_str_tf(tensor.dtype)
+
+    @dlp.log
+    def _map_dtype_to_str_tf(self, dtype):
+        # Maps TensorFlow dtype objects to specific strings
+        if dtype == tf.float32: return "fp32"
+        if dtype == tf.float16: return "fp16"
+        if dtype == tf.bfloat16: return "bf16"
+        if dtype == tf.int8: return "int8"
+        if dtype == tf.uint8: return "uint8"
+        if dtype == tf.float64: return "fp64"
+        # Minimal fallback using TensorFlow's built-in dtype name
+        return dtype.name
+
+    @dlp.log
+    def get_tensor_core(self, length, datatype="int8"):
         return tf.ones((length), dtype=get_tf_datatype(datatype))
 
     @dlp.log
-    def save_state(self, suffix, state, fsync = False):
+    def save_state_core(self, suffix, state, fsync = False):
         name = self.get_name(suffix)
         checkpoint = tf.train.Checkpoint()
         checkpoint.mapped = state

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -134,6 +134,8 @@ class ConfigArguments:
     iostat_devices: ClassVar[List[str]] = []
     data_loader_classname = None
     checkpoint_mechanism_classname = None
+    hash_consing: bool = False
+    hash_consing_chunk_size: int = 1
     data_loader_sampler: DataLoaderSampler = None
     reader_classname: str = None
     multiprocessing_context: str = "fork"
@@ -617,6 +619,10 @@ def GetConfig(args, key):
             value = args.checkpoint_rank_sync
         elif keys[1] == "recovery_rank_shift":  
             value = args.checkpoint_recovery_rank_shift
+        elif keys[1] == "hash_consing":
+            value = args.hash_consing
+        elif keys[1] == "hash_consing_chunk_size":
+            value = args.hash_consing_chunk_size
 
     if len(keys) > 1 and keys[0] == "model":
         if keys[1] == "name":
@@ -876,6 +882,10 @@ def LoadConfig(args, config):
             args.checkpoint_rank_sync = config['checkpoint']['rank_sync']
         if 'mode' in config['checkpoint']:
             args.checkpoint_mode = CheckpointModeType(config['checkpoint']['mode'])
+        if 'hash_consing' in config['checkpoint']:
+            args.hash_consing = config['checkpoint']['hash_consing']
+        if 'hash_consing_chunk_size' in config['checkpoint']:
+            args.hash_consing_chunk_size = config['checkpoint']['hash_consing_chunk_size']
 
     if 'model' in config:
         if 'name' in config['model']:


### PR DESCRIPTION
Creates two LUTs to decrease RAM usage by reusing identical tensors.
Detailed algorithm explaination is in the save_state function. 
With this patch, we can use an amount of RAM far below the actual model size.
It seems to work. 

**RAM usage with/without + performance comparison**
I removed the Y right axis details, as it represent real performance number in GB/s for read and write, but it start at 0.
The objective here is to demonstrate that the performance is the same, while the RAM usage decreases a lot.
C= chunksize. This value makes sense if you read the detailed explaination. I have set the default at 1. 


![hash_consing](https://github.com/user-attachments/assets/40faee53-8224-4b1b-8262-2090587b1b19)


**Write verification**
This is the amount of data available on disk after each write test (1 iter)
|         in %            | Normal | hash + C=8 | hash + C=4 | hash + C=2 | hash + C=1 | hash+ C=1 + #281  | Normal + #281 |
|---------------------|--------|------------|------------|------------|------------|--------------|----------------|
| Data on disk after 1 write iter | 100      | 99,99629   | 99,99989   | 99,99592   | 99,99874   | 100,0001     | 99,99937       |

**Raw grafana view**
memory usage (1 write then 1 read, clean cache in between, visible on this graph)
normal, hash+C1, hash+C2,hash+C4, hash+C8
![mem](https://github.com/user-attachments/assets/1ccee24a-9e70-404d-9891-5bada2830a13)

network usage measured on the client (read)
There are two colors but it's just because there are two network interface.
normal, hash+C1, hash+C2,hash+C4, hash+C8
![READ_IB](https://github.com/user-attachments/assets/e1c8879e-fda5-407f-a8b1-a978546ff4b7)

network usage measured on the client (write)
Same
normal, hash+C1, hash+C2,hash+C4, hash+C8
![WRITE_IB](https://github.com/user-attachments/assets/966b62c5-e5e7-41ef-a627-927fa2db78f1)

**Important**
To make it work, the optimizer state write/read operation are chunked, which is fine from my perspective but it does change the algorithm a bit. It creates multiple files, as it is done with the layers of the model  when DP is above 0. 

Can be enabled/disabled with:
`++workload.checkpoint.hash_consing=True/False (default: False)`

Can be tuned with:
`++workload.checkpoint.hash_consing_chunk_size=1 (default: 1) Increasing the value increases memory usage.
`
Default is the minimum RAM usage.
