### PR TITLE
Fix issues with tensorflow tf generator support for Object Storage

### DIFF
--- a/dlio_benchmark/data_generator/tf_generator.py
+++ b/dlio_benchmark/data_generator/tf_generator.py
@@ -77,6 +77,6 @@ class TFRecordGenerator(DataGenerator):
             filename = os.path.basename(out_path_spec)
             self.storage.create_node(index_folder, exist_ok=True)
             tfrecord_idx = f"{index_folder}/{filename}.idx"
-            if not os.path.isfile(tfrecord_idx):
-                call([tfrecord2idx_script, out_path_spec, tfrecord_idx])
+            if not self.storage.isfile(tfrecord_idx):
+                call([tfrecord2idx_script, out_path_spec, self.storage.get_uri(tfrecord_idx)])
         np.random.seed()

--- a/dlio_benchmark/framework/framework.py
+++ b/dlio_benchmark/framework/framework.py
@@ -105,3 +105,6 @@ class Framework(ABC):
     def get_data(self, id, data, offset=None, length=None):
         return None
 
+    def isfile(self, id):
+        return False
+

--- a/dlio_benchmark/storage/file_storage.py
+++ b/dlio_benchmark/storage/file_storage.py
@@ -99,5 +99,9 @@ class FileStorage(DataStorage):
             data = fd.read()
         return data
     
+    @dlp.log
+    def isfile(self, id):
+        return os.path.isfile(id)
+
     def get_basename(self, id):
         return os.path.basename(id)

--- a/dlio_benchmark/storage/s3_storage.py
+++ b/dlio_benchmark/storage/s3_storage.py
@@ -72,5 +72,9 @@ class S3Storage(DataStorage):
     def get_data(self, id, data, offset=None, length=None):
         return super().get_data(self.get_uri(id), data, offset, length)
 
+    @dlp.log
+    def isfile(self, id):
+        return super().isfile(self.get_uri(id))
+
     def get_basename(self, id):
         return os.path.basename(id)

--- a/dlio_benchmark/storage/storage_handler.py
+++ b/dlio_benchmark/storage/storage_handler.py
@@ -123,3 +123,10 @@ class DataStorage(ABC):
             return self.framework.get_data(id, data, offset, length)
         return None
 
+    def isfile(self, id):
+        """
+            This method checks if the given path is a file
+        """
+        if self.is_framework_nativeio_available:
+            return self.framework.isfile(id)
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,9 @@ pandas>=1.5.1
 psutil>=5.9.8
 pydftracer==1.0.11
 pytest
-tensorflow>=2.11.0
+tensorflow==2.13.1
+tensorflow_io==0.33.0
 torch>=2.2.0
 torchaudio
 torchvision
+boto3

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,13 @@ core_deps = [
     "omegaconf>=2.2.0",
     "pandas>=1.5.1",
     "psutil>=5.9.8",
+    "boto3",
 ]
 x86_deps = [
     f"hydra-core>={HYDRA_VERSION}",
     "nvidia-dali-cuda120>=1.34.0",
-    "tensorflow>=2.11.0",
+    "tensorflow==2.13.1",
+    "tensorflow_io==0.33.0",
     "torch>=2.2.0",
     "torchaudio",
     "torchvision",


### PR DESCRIPTION
Found a few bugs when I run MLPerf storage on Object Storage:

1. tfrecord index files are still pointing to local FS path rather than object path. 
    - Update index file paths to include ``s3://``.
2. When creating node, unable to create intermediate directories. 
    - Use ``makedirs`` instead of ``mkdir`` to create intermediate dirs.
3. ``walk_node`` is using ``tf.io.gfile.listdir``, which has a bug that causes out-of-index for substr.
    - Use boto3 ``list_object_v2``.