### PR TITLE
Fixes for v2.0 benchmark

### DIFF
--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -348,7 +348,7 @@ class DLIOBenchmark(object):
             if overall_step > max_steps or ((self.total_training_steps > 0) and (overall_step > self.total_training_steps)):
                 if self.args.my_rank == 0:
                     self.logger.info(f"{utcnow()} Maximum number of steps reached")
-                if (not self.do_checkpoint):
+                if (block_step != 1 and self.do_checkpoint) or (not self.do_checkpoint):
                     self.stats.end_block(epoch, block, block_step - 1)
                 break
             # start a new block here

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -488,7 +488,7 @@ def GetConfig(args, key):
     if len(keys) > 1 and keys[0] == "dataset":
         if keys[1] == "record_length_bytes":
             value = args.record_length
-        elif keys[1] == "record_length_byte_stdev":
+        elif keys[1] == "record_length_bytes_stdev":
             value = args.record_length_stdev
         elif keys[1] == "record_length_bytes_resize":
             value = args.record_length_resize
@@ -709,7 +709,7 @@ def LoadConfig(args, config):
     if 'dataset' in config:
         if 'record_length_bytes' in config['dataset']:
             args.record_length = config['dataset']['record_length_bytes']
-        if 'record_length_byte_stdev' in config['dataset']:
+        if 'record_length_bytes_stdev' in config['dataset']:
             args.record_length_stdev = config['dataset']['record_length_bytes_stdev']
         if 'record_length_bytes_resize' in config['dataset']:
             args.record_length_resize = config['dataset']['record_length_bytes_resize']


### PR DESCRIPTION
1. end_block is not called for checkpoint enabled workloads(eg: unet3d) . Stats are currently wrong (Ref commit: https://github.com/argonne-lcf/dlio_benchmark/pull/253/files#diff-763f5c93c1c2ccf78bad4c6555e3465b457c7546d76b1a0815a1f0a1a29c2365) 
2. std_dev is not used in the current installation and hence generated file sizes are wrong. 