### PR TITLE
Randomize tensor data by default (checkpoint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,12 @@ jobs:
           mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers3-2-layer_params3-3-True] -v
           mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers4-1-layer_params4-0-True] -v
           mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers5-1-layer_params5-0-True] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers0-2-layer_params0-0-False] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers1-2-layer_params1-0-False] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers2-2-layer_params2-3-False] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers3-2-layer_params3-3-False] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers4-1-layer_params4-0-False] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers5-1-layer_params5-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers6-2-layer_params6-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers7-2-layer_params7-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers8-2-layer_params8-3-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers9-2-layer_params9-3-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers10-1-layer_params10-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers11-1-layer_params11-0-False] -v
           rm -rf data
       - name: test_checkpoint_ksm_config
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,18 @@ jobs:
       - name: test_checkpoint_epoch
         run: |
           source ${VENV_PATH}/bin/activate
-          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers0-2-layer_params0-0] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers1-2-layer_params1-0] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers2-2-layer_params2-3] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers3-2-layer_params3-3] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers4-1-layer_params4-0] -v
-          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers5-1-layer_params5-0] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers0-2-layer_params0-0-True] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers1-2-layer_params1-0-True] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers2-2-layer_params2-3-True] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers3-2-layer_params3-3-True] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers4-1-layer_params4-0-True] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers5-1-layer_params5-0-True] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers0-2-layer_params0-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers1-2-layer_params1-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers2-2-layer_params2-3-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers3-2-layer_params3-3-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[tensorflow-1024-optimizers4-1-layer_params4-0-False] -v
+          mpirun -np 2 pytest -k test_checkpoint_epoch[pytorch-1024-optimizers5-1-layer_params5-0-False] -v
           rm -rf data
       - name: test_checkpoint_ksm_config
         run: |

--- a/dlio_benchmark/checkpointing/pytorch_checkpointing.py
+++ b/dlio_benchmark/checkpointing/pytorch_checkpointing.py
@@ -61,8 +61,19 @@ class PyTorchCheckpointing(BaseCheckpointing):
         super().__init__("pt")
 
     @dlp.log
-    def get_tensor_core(self, length, datatype="int8"):
-        return torch.ones(length, dtype=get_torch_datatype(datatype))
+    def get_tensor_core(self, length, datatype="int8", randomize=True):
+        torch_dtype=get_torch_datatype(datatype)
+        if randomize:
+            if torch_dtype in [torch.float32, torch.float16, torch.float64, torch.bfloat16]:
+                return torch.rand(length, dtype=torch_dtype)
+            elif torch_dtype == torch.int8:
+                return torch.randint(low=-128,high=128, size=(length,), dtype=torch_dtype)
+            elif torch_dtype == torch.uint8:
+                return torch.randint(low=0, high=256, size=(length,), dtype=torch_dtype)
+            else:
+                raise Exception(f"Datatype {torch_dtype} cannot be randomized for random tensor generation.")
+        else:
+            return torch.ones(length, dtype=torch_dtype)
 
     @dlp.log
     def set_madvise_mergeable(self, tensor):

--- a/dlio_benchmark/checkpointing/tf_checkpointing.py
+++ b/dlio_benchmark/checkpointing/tf_checkpointing.py
@@ -64,9 +64,11 @@ class TFCheckpointing(BaseCheckpointing):
             if tf_dtype in [tf.float16, tf.float32, tf.float64, tf.bfloat16]:
                 return tf.random.uniform(shape=(length,), minval=0, maxval=1, dtype=tf_dtype)
             elif tf_dtype == tf.int8:
-                return tf.random.uniform(shape=(length,), minval=-128, maxval=128, dtype=tf_dtype)
+                random_tensor = tf.random.uniform(shape=(length,), minval=-128, maxval=128, dtype=tf.int32)
+                return tf.cast(random_tensor, dtype=tf.int8)
             elif tf_dtype == tf.uint8:
-                return tf.random.uniform(shape=(length,), minval=0, maxval=256, dtype=tf_dtype)
+                random_tensor = tf.random.uniform(shape=(length,), minval=0, maxval=256, dtype=tf.int32)
+                return tf.cast(random_tensor, dtype=tf.uint8)
             else:
                  raise Exception(f"Datatype {tf_dtype} cannot be randomized for random tensor generation.")
         return tf.ones((length), dtype=tf_dtype)

--- a/dlio_benchmark/checkpointing/tf_checkpointing.py
+++ b/dlio_benchmark/checkpointing/tf_checkpointing.py
@@ -58,8 +58,18 @@ class TFCheckpointing(BaseCheckpointing):
         super().__init__("pb")
 
     @dlp.log
-    def get_tensor_core(self, length, datatype="int8"):
-        return tf.ones((length), dtype=get_tf_datatype(datatype))
+    def get_tensor_core(self, length, datatype="int8", randomize=True):
+        tf_dtype = get_tf_datatype(datatype)
+        if randomize:
+            if tf_dtype in [tf.float16, tf.float32, tf.float64, tf.bfloat16]:
+                return tf.random.uniform(shape=(length,), minval=0, maxval=1, dtype=tf_dtype)
+            elif tf_dtype == tf.int8:
+                return tf.random.uniform(shape=(length,), minval=-128, maxval=128, dtype=tf_dtype)
+            elif tf_dtype == tf.uint8:
+                return tf.random.uniform(shape=(length,), minval=0, maxval=256, dtype=tf_dtype)
+            else:
+                 raise Exception(f"Datatype {tf_dtype} cannot be randomized for random tensor generation.")
+        return tf.ones((length), dtype=tf_dtype)
 
     @dlp.log
     def set_madvise_mergeable(self, tensor):

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -114,6 +114,7 @@ class ConfigArguments:
     checkpoint_rank_sync: bool = False
     num_checkpoints_write: int = -1
     num_checkpoints_read: int = -1
+    checkpoint_randomize_tensor: bool = True
     ksm_madv_mergeable_id: int = 12
     ksm_high_ram_trigger: float = 30.0
     ksm_low_ram_exit: float = 15
@@ -886,7 +887,8 @@ def LoadConfig(args, config):
             args.checkpoint_rank_sync = config['checkpoint']['rank_sync']
         if 'mode' in config['checkpoint']:
             args.checkpoint_mode = CheckpointModeType(config['checkpoint']['mode'])
-
+        if 'randomize_tensor' in config['checkpoint']:
+            args.checkpoint_randomize_tensor = config['checkpoint']['randomize_tensor']
         if 'ksm' in config['checkpoint']:
             args.ksm_present = True
             if 'madv_mergeable_id' in config['checkpoint']['ksm']:

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -441,6 +441,9 @@ checkpoint
      - default
      - | The mode of the checkpointing.
        | Available options are: default, subset.
+   * - randomize_tensor
+     - True
+     - | randomize the tensors data
    * - ksm
      - (omitted)
      - | Optional subsection to configure and enable Kernel Samepage Merging (KSM) optimization.

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -226,7 +226,7 @@ def test_iostat_profiling() -> None:
     finalize()
 
 @pytest.mark.timeout(60, method="thread")
-@pytest.mark.parametrize("framework, model_size, optimizers, num_layers, layer_params, zero_stage", [("tensorflow", 1024, [1024, 128], 2, [16], 0, True),
+@pytest.mark.parametrize("framework, model_size, optimizers, num_layers, layer_params, zero_stage, randomize", [("tensorflow", 1024, [1024, 128], 2, [16], 0, True),
                                                                                          ("pytorch", 1024, [1024, 128], 2, [16], 0, True),
                                                                                          ("tensorflow", 1024, [1024, 128], 2, [16], 3, True),
                                                                                          ("pytorch", 1024, [1024, 128], 2, [16], 3, True),
@@ -254,7 +254,7 @@ def test_checkpoint_epoch(framework, model_size, optimizers, num_layers, layer_p
                                  f'++workload.reader.data_loader={framework}',
                                  '++workload.workflow.train=True',
                                  '++workload.workflow.generate_data=True',
-                                 f'++workload.checkpoint.randomize_tensor={randomize}'
+                                 f'++workload.checkpoint.randomize_tensor={randomize}',
                                  '++workload.train.computation_time=0.01',
                                  '++workload.evaluation.eval_time=0.005',
                                  f'++workload.train.epochs={epochs}', '++workload.workflow.checkpoint=True',

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -226,12 +226,18 @@ def test_iostat_profiling() -> None:
     finalize()
 
 @pytest.mark.timeout(60, method="thread")
-@pytest.mark.parametrize("framework, model_size, optimizers, num_layers, layer_params, zero_stage", [("tensorflow", 1024, [1024, 128], 2, [16], 0),
-                                                                                         ("pytorch", 1024, [1024, 128], 2, [16], 0),
-                                                                                         ("tensorflow", 1024, [1024, 128], 2, [16], 3),
-                                                                                         ("pytorch", 1024, [1024, 128], 2, [16], 3),
-                                                                                         ("tensorflow", 1024, [128], 1, [16], 0),
-                                                                                         ("pytorch", 1024, [128], 1, [16], 0)])
+@pytest.mark.parametrize("framework, model_size, optimizers, num_layers, layer_params, zero_stage", [("tensorflow", 1024, [1024, 128], 2, [16], 0, True),
+                                                                                         ("pytorch", 1024, [1024, 128], 2, [16], 0, True),
+                                                                                         ("tensorflow", 1024, [1024, 128], 2, [16], 3, True),
+                                                                                         ("pytorch", 1024, [1024, 128], 2, [16], 3, True),
+                                                                                         ("tensorflow", 1024, [128], 1, [16], 0, True),
+                                                                                         ("pytorch", 1024, [128], 1, [16], 0, True),
+                                                                                         ("tensorflow", 1024, [1024, 128], 2, [16], 0, False),
+                                                                                         ("pytorch", 1024, [1024, 128], 2, [16], 0, False),
+                                                                                         ("tensorflow", 1024, [1024, 128], 2, [16], 3, False),
+                                                                                         ("pytorch", 1024, [1024, 128], 2, [16], 3, False),
+                                                                                         ("tensorflow", 1024, [128], 1, [16], 0, False),
+                                                                                         ("pytorch", 1024, [128], 1, [16], 0, False)])
 def test_checkpoint_epoch(framework, model_size, optimizers, num_layers, layer_params, zero_stage, randomize) -> None:
     init()
     clean()

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -232,7 +232,7 @@ def test_iostat_profiling() -> None:
                                                                                          ("pytorch", 1024, [1024, 128], 2, [16], 3),
                                                                                          ("tensorflow", 1024, [128], 1, [16], 0),
                                                                                          ("pytorch", 1024, [128], 1, [16], 0)])
-def test_checkpoint_epoch(framework, model_size, optimizers, num_layers, layer_params, zero_stage) -> None:
+def test_checkpoint_epoch(framework, model_size, optimizers, num_layers, layer_params, zero_stage, randomize) -> None:
     init()
     clean()
     if comm.rank == 0:
@@ -248,6 +248,7 @@ def test_checkpoint_epoch(framework, model_size, optimizers, num_layers, layer_p
                                  f'++workload.reader.data_loader={framework}',
                                  '++workload.workflow.train=True',
                                  '++workload.workflow.generate_data=True',
+                                 f'++workload.checkpoint.randomize_tensor={randomize}'
                                  '++workload.train.computation_time=0.01',
                                  '++workload.evaluation.eval_time=0.005',
                                  f'++workload.train.epochs={epochs}', '++workload.workflow.checkpoint=True',


### PR DESCRIPTION
Addresses Russ's discussion on using tensors filled with ones for checkpointing for MLPerf storage.

This PR changes the default behavior to use randomized tensor data for checkpoints.
To revert to tensors filled with ones, use the Hydra override:
`++workload.checkpoint.randomize_tensor=false`

The PR hasn't been tested yet. 