### PR TITLE
Add DFTracer AI logging support with dftracer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,16 @@ jobs:
           source ${VENV_PATH}/bin/activate
           pip install --upgrade pip
           pip install -r requirements.txt
+      - name: test_ai_logging
+        run: |
+          source ${VENV_PATH}/bin/activate
+          mpirun -np 2 pytest -k test_ai_logging_train[pytorch] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[tensorflow] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[pytorch-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[tensorflow-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_eval[pytorch] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_eval[tensorflow] -v
+          rm -rf outputs
       - name: test_checkpoint_epoch
         run: |
           source ${VENV_PATH}/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,74 @@ jobs:
       - name: test_ai_logging
         run: |
           source ${VENV_PATH}/bin/activate
-          mpirun -np 2 pytest -k test_ai_logging_train[pytorch] -v
-          mpirun -np 2 pytest -k test_ai_logging_train[tensorflow] -v
-          mpirun -np 2 pytest -k test_ai_logging_train_with_step[pytorch-3] -v
-          mpirun -np 2 pytest -k test_ai_logging_train_with_step[tensorflow-3] -v
+
+          mpirun -np 2 pytest -k test_ai_logging_train[pytorch-9-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[pytorch-9-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[pytorch-10-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[pytorch-10-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[tensorflow-9-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[tensorflow-9-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[tensorflow-10-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train[tensorflow-10-3] -v
+
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[pytorch-2-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[pytorch-2-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[pytorch-3-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[pytorch-3-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[tensorflow-2-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[tensorflow-2-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[tensorflow-3-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_step[tensorflow-3-3] -v
+
           mpirun -np 2 pytest -k test_ai_logging_with_eval[pytorch] -v
           mpirun -np 2 pytest -k test_ai_logging_with_eval[tensorflow] -v
+
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-hdf5] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-npy] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-npz] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-csv] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-jpeg] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-png] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-indexed_binary] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-mmap_indexed_binary] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[pytorch-synthetic] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-hdf5] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-npy] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-npz] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-tfrecord] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-csv] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-jpeg] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-png] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-indexed_binary] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-mmap_indexed_binary] -v
+          mpirun -np 2 pytest -k test_ai_logging_with_reader[tensorflow-synthetic] -v
+
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[pytorch-1-na] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[pytorch-1-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[pytorch-1-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[pytorch-2-na] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[pytorch-2-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[pytorch-2-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[tensorflow-1-na] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[tensorflow-1-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[tensorflow-1-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[tensorflow-2-na] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[tensorflow-2-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint[tensorflow-2-2] -v
+
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[pytorch-3-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[pytorch-3-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[pytorch-3-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[pytorch-4-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[pytorch-4-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[pytorch-4-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[tensorflow-3-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[tensorflow-3-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[tensorflow-3-3] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[tensorflow-4-1] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[tensorflow-4-2] -v
+          mpirun -np 2 pytest -k test_ai_logging_train_with_checkpoint_only[tensorflow-4-3] -v
+         
           rm -rf outputs
       - name: test_checkpoint_epoch
         run: |

--- a/dlio_benchmark/checkpointing/base_checkpointing.py
+++ b/dlio_benchmark/checkpointing/base_checkpointing.py
@@ -431,7 +431,7 @@ class BaseCheckpointing(ABC):
         self.checkpoint_storage.create_node(checkpoint_id, exist_ok=True)
         if self.rank_to_checkpoint == my_rank:
             if self.model_state:
-                self.load_state(suffix=f"{checkpoint_id}/model_states-{my_rank}", state=self.model_state, fsync = self.args.checkpoint_fsync)
+                self.load_state(suffix=f"{checkpoint_id}/model_states-{my_rank}", state=self.model_state)
             
             if self.layer_state:
                 start_time = time.time()
@@ -443,7 +443,7 @@ class BaseCheckpointing(ABC):
                             for layer_index in range(start_layer, end_layer + 1):
                                 self.load_state(suffix=f"{checkpoint_id}/layer_{layer_index}-model_{self.model_parallelism_rank}_model_states", state=self.layer_state[str(layer_index)])
                         else:
-                            self.load_state(suffix=f"{checkpoint_id}/model_{self.model_parallelism_rank}_model_states", state=self.layer_state, fsync = self.args.checkpoint_fsync)
+                            self.load_state(suffix=f"{checkpoint_id}/model_{self.model_parallelism_rank}_model_states", state=self.layer_state)
                 else:
                     # in this case, model is sharded across the data parallel ranks
                     assert(self.args.pipeline_parallelism == 1)

--- a/dlio_benchmark/checkpointing/pytorch_checkpointing.py
+++ b/dlio_benchmark/checkpointing/pytorch_checkpointing.py
@@ -18,7 +18,7 @@ import os
 import torch
 import ctypes
 from dlio_benchmark.checkpointing.base_checkpointing import BaseCheckpointing
-from dlio_benchmark.utils.utility import Profile, ai
+from dlio_benchmark.utils.utility import Profile, dft_ai
 
 from dlio_benchmark.common.constants import MODULE_CHECKPOINT
 
@@ -52,7 +52,7 @@ class PyTorchCheckpointing(BaseCheckpointing):
             PyTorchCheckpointing.__instance = PyTorchCheckpointing()
         return PyTorchCheckpointing.__instance
 
-    @ai.checkpoint.init
+    @dft_ai.checkpoint.init
     def __init__(self):
         super().__init__("pt")
 
@@ -123,7 +123,7 @@ class PyTorchCheckpointing(BaseCheckpointing):
         except Exception:
             return False
 
-    @ai.checkpoint.capture
+    @dft_ai.checkpoint.capture
     def save_state(self, suffix, state, fsync = False):
         name = self.get_name(suffix)
         with open(name, "wb") as f:
@@ -131,7 +131,7 @@ class PyTorchCheckpointing(BaseCheckpointing):
             if fsync: 
                 os.fsync(f.fileno())
 
-    @ai.checkpoint.restart
+    @dft_ai.checkpoint.restart
     def load_state(self, suffix, state):
         name = self.get_name(suffix)
         state = dict() # clear up

--- a/dlio_benchmark/checkpointing/pytorch_checkpointing.py
+++ b/dlio_benchmark/checkpointing/pytorch_checkpointing.py
@@ -17,14 +17,10 @@
 import os
 import torch
 import ctypes
-import time
 from dlio_benchmark.checkpointing.base_checkpointing import BaseCheckpointing
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, ai
 
 from dlio_benchmark.common.constants import MODULE_CHECKPOINT
-from dlio_benchmark.common.enumerations import CheckpointLocationType
-from dlio_benchmark.utils.utility import DLIOMPI
-import logging
 
 def get_torch_datatype(datatype):
     if datatype == "fp32":
@@ -56,7 +52,7 @@ class PyTorchCheckpointing(BaseCheckpointing):
             PyTorchCheckpointing.__instance = PyTorchCheckpointing()
         return PyTorchCheckpointing.__instance
 
-    @dlp.log_init
+    @ai.checkpoint.init
     def __init__(self):
         super().__init__("pt")
 
@@ -75,7 +71,6 @@ class PyTorchCheckpointing(BaseCheckpointing):
         else:
             return torch.ones(length, dtype=torch_dtype)
 
-    @dlp.log
     def set_madvise_mergeable(self, tensor):
         """
         Apply MADV_MERGEABLE to a PyTorch tensor's memory region with alignment handling.
@@ -128,7 +123,7 @@ class PyTorchCheckpointing(BaseCheckpointing):
         except Exception:
             return False
 
-    @dlp.log
+    @ai.checkpoint.capture
     def save_state(self, suffix, state, fsync = False):
         name = self.get_name(suffix)
         with open(name, "wb") as f:
@@ -136,7 +131,7 @@ class PyTorchCheckpointing(BaseCheckpointing):
             if fsync: 
                 os.fsync(f.fileno())
 
-    @dlp.log
+    @ai.checkpoint.restart
     def load_state(self, suffix, state):
         name = self.get_name(suffix)
         state = dict() # clear up

--- a/dlio_benchmark/checkpointing/tf_checkpointing.py
+++ b/dlio_benchmark/checkpointing/tf_checkpointing.py
@@ -14,15 +14,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import os
-
-from dlio_benchmark.checkpointing.base_checkpointing import BaseCheckpointing
-from dlio_benchmark.utils.utility import Profile, ai
 import tensorflow as tf
 
 from dlio_benchmark.common.constants import MODULE_CHECKPOINT
-from dlio_benchmark.common.enumerations import CheckpointLocationType
-from dlio_benchmark.utils.utility import DLIOMPI, utcnow
+from dlio_benchmark.checkpointing.base_checkpointing import BaseCheckpointing
+from dlio_benchmark.utils.utility import Profile, dft_ai
+from dlio_benchmark.utils.utility import utcnow
 
 def get_tf_datatype(datatype):
     if datatype == "fp32":
@@ -53,7 +50,7 @@ class TFCheckpointing(BaseCheckpointing):
             TFCheckpointing.__instance = TFCheckpointing()
         return TFCheckpointing.__instance
     
-    @ai.checkpoint.init
+    @dft_ai.checkpoint.init
     def __init__(self):
         super().__init__("pb")
 
@@ -77,14 +74,14 @@ class TFCheckpointing(BaseCheckpointing):
     def set_madvise_mergeable(self, tensor):
         return False
 
-    @ai.checkpoint.capture
+    @dft_ai.checkpoint.capture
     def save_state(self, suffix, state, fsync = False):
         name = self.get_name(suffix)
         checkpoint = tf.train.Checkpoint()
         checkpoint.mapped = state
         checkpoint.save(name)
 
-    @ai.checkpoint.restart
+    @dft_ai.checkpoint.restart
     def load_state(self, suffix, state):
         name = self.get_name(suffix)
         state = dict() # clear up

--- a/dlio_benchmark/checkpointing/tf_checkpointing.py
+++ b/dlio_benchmark/checkpointing/tf_checkpointing.py
@@ -17,7 +17,7 @@
 import os
 
 from dlio_benchmark.checkpointing.base_checkpointing import BaseCheckpointing
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, ai
 import tensorflow as tf
 
 from dlio_benchmark.common.constants import MODULE_CHECKPOINT
@@ -53,7 +53,7 @@ class TFCheckpointing(BaseCheckpointing):
             TFCheckpointing.__instance = TFCheckpointing()
         return TFCheckpointing.__instance
     
-    @dlp.log_init
+    @ai.checkpoint.init
     def __init__(self):
         super().__init__("pb")
 
@@ -77,14 +77,14 @@ class TFCheckpointing(BaseCheckpointing):
     def set_madvise_mergeable(self, tensor):
         return False
 
-    @dlp.log
+    @ai.checkpoint.capture
     def save_state(self, suffix, state, fsync = False):
         name = self.get_name(suffix)
         checkpoint = tf.train.Checkpoint()
         checkpoint.mapped = state
         checkpoint.save(name)
 
-    @dlp.log
+    @ai.checkpoint.restart
     def load_state(self, suffix, state):
         name = self.get_name(suffix)
         state = dict() # clear up

--- a/dlio_benchmark/data_loader/dali_data_loader.py
+++ b/dlio_benchmark/data_loader/dali_data_loader.py
@@ -24,7 +24,7 @@ from dlio_benchmark.common.constants import MODULE_DATA_LOADER
 from dlio_benchmark.common.enumerations import DataLoaderType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow, Profile, DLIOLogger, ai
+from dlio_benchmark.utils.utility import utcnow, Profile, DLIOLogger, dft_ai
 
 dlp = Profile(MODULE_DATA_LOADER)
 
@@ -136,23 +136,24 @@ class DaliDataLoader(BaseDataLoader):
         self.read(True)
         while step < self.num_samples // self.batch_size:
             for pipe in self.pipelines:
-                ai.dataloader.fetch.start()
+                dft_ai.dataloader.fetch.start()
                 try:
                     outputs = pipe.share_outputs()
                 except StopIteration:
-                    # it is fine to not stop `ai.dataloader.fetch` here
+                    # it is fine to not stop `dft_ai.dataloader.fetch` here since
+                    # it will be reset at the next run
                     return
-                ai.dataloader.fetch.stop()
+                dft_ai.dataloader.fetch.stop()
                 self.logger.debug(f"{utcnow()} Output batch {step} {len(outputs)}")
                 yield outputs
                 step += 1
                 dlp.update(step=step)
-                ai.update(step=step)
+                dft_ai.update(step=step)
                 pipe.release_outputs()
                 pipe.schedule_run()
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
-        ai.update(epoch=self.epoch_number)
+        dft_ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/native_dali_data_loader.py
+++ b/dlio_benchmark/data_loader/native_dali_data_loader.py
@@ -21,7 +21,7 @@ from dlio_benchmark.common.constants import MODULE_DATA_LOADER
 from dlio_benchmark.common.enumerations import DataLoaderType, DatasetType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow, Profile, ai
+from dlio_benchmark.utils.utility import utcnow, Profile, dft_ai
 
 dlp = Profile(MODULE_DATA_LOADER)
 
@@ -67,16 +67,16 @@ class NativeDaliDataLoader(BaseDataLoader):
             pipeline.reset()
         for step in range(num_samples // batch_size):
             dlp.update(step=step)
-            ai.update(step=step)
+            dft_ai.update(step=step)
             try:
-                for batch in ai.dataloader.fetch.iter(self._dataset):
+                for batch in dft_ai.dataloader.fetch.iter(self._dataset):
                     self.logger.debug(f"{utcnow()} Creating {len(batch)} batches by {self._args.my_rank} rank ")
                     yield batch
             except StopIteration:
                 return
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
-        ai.update(epoch=self.epoch_number)
+        dft_ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/synthetic_data_loader.py
+++ b/dlio_benchmark/data_loader/synthetic_data_loader.py
@@ -33,6 +33,10 @@ class SyntheticDataLoader(BaseDataLoader):
     @dlp.log
     def read(self, init=False):
         return
+    
+    @ai.data.item
+    def getitem(self):
+        return self.batch
 
     @dlp.log
     def next(self):
@@ -47,7 +51,7 @@ class SyntheticDataLoader(BaseDataLoader):
             dlp.update(step=step)
             ai.update(step=step)
             step += 1
-            yield self.batch
+            yield self.getitem()
             ai.dataloader.fetch.start()
 
         self.epoch_number += 1

--- a/dlio_benchmark/data_loader/synthetic_data_loader.py
+++ b/dlio_benchmark/data_loader/synthetic_data_loader.py
@@ -19,7 +19,7 @@ import numpy as np
 from dlio_benchmark.common.constants import MODULE_DATA_LOADER
 from dlio_benchmark.common.enumerations import DataLoaderType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
-from dlio_benchmark.utils.utility import utcnow, Profile, ai
+from dlio_benchmark.utils.utility import utcnow, Profile, dft_ai
 
 dlp = Profile(MODULE_DATA_LOADER)
 
@@ -34,7 +34,7 @@ class SyntheticDataLoader(BaseDataLoader):
     def read(self, init=False):
         return
     
-    @ai.data.item
+    @dft_ai.data.item
     def getitem(self):
         return self.batch
 
@@ -45,18 +45,18 @@ class SyntheticDataLoader(BaseDataLoader):
         self.read(True)
 
         step = 1
-        ai.dataloader.fetch.start()
+        dft_ai.dataloader.fetch.start()
         while step < self.num_samples // self.batch_size:
-            ai.dataloader.fetch.stop()
+            dft_ai.dataloader.fetch.stop()
             dlp.update(step=step)
-            ai.update(step=step)
+            dft_ai.update(step=step)
             step += 1
             yield self.getitem()
-            ai.dataloader.fetch.start()
+            dft_ai.dataloader.fetch.start()
 
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
-        ai.update(epoch=self.epoch_number)
+        dft_ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/synthetic_data_loader.py
+++ b/dlio_benchmark/data_loader/synthetic_data_loader.py
@@ -14,21 +14,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from time import time
-import logging
-import math
 import numpy as np
-from nvidia.dali.pipeline import Pipeline
-import nvidia.dali.fn as fn
-import nvidia.dali.types as types
 
 from dlio_benchmark.common.constants import MODULE_DATA_LOADER
-from dlio_benchmark.common.enumerations import Shuffle, DataLoaderType, DatasetType
+from dlio_benchmark.common.enumerations import DataLoaderType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
-from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile
-import os
+from dlio_benchmark.utils.utility import utcnow, Profile, ai
 
 dlp = Profile(MODULE_DATA_LOADER)
 
@@ -38,7 +29,6 @@ class SyntheticDataLoader(BaseDataLoader):
         super().__init__(format_type, dataset_type, epoch, DataLoaderType.SYNTHETIC)
         shape = self._args.resized_image.shape
         self.batch = np.zeros((self.batch_size, shape[0], shape[1]))
-        #self.batch = 1
 
     @dlp.log
     def read(self, init=False):
@@ -48,11 +38,21 @@ class SyntheticDataLoader(BaseDataLoader):
     def next(self):
         super().next()
         self.logger.debug(f"{utcnow()} Iterating pipelines by {self._args.my_rank} rank ")
-        step = 0
         self.read(True)
+
+        step = 1
+        ai.dataloader.fetch.start()
         while step < self.num_samples // self.batch_size:
-            yield self.batch
+            ai.dataloader.fetch.stop()
+            dlp.update(step=step)
+            ai.update(step=step)
             step += 1
+            yield self.batch
+            ai.dataloader.fetch.start()
+
+        self.epoch_number += 1
+        dlp.update(epoch=self.epoch_number)
+        ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/tf_data_loader.py
+++ b/dlio_benchmark/data_loader/tf_data_loader.py
@@ -14,18 +14,14 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from time import time
-import logging
-import math
 
 import tensorflow as tf
 
 from dlio_benchmark.common.constants import MODULE_DATA_LOADER
-from dlio_benchmark.common.enumerations import DataLoaderType, Shuffle, FormatType, DatasetType
+from dlio_benchmark.common.enumerations import DataLoaderType, FormatType, DatasetType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile, DLIOLogger
+from dlio_benchmark.utils.utility import utcnow, Profile, DLIOLogger, ai
 
 import numpy as np
 
@@ -100,12 +96,16 @@ class TFDataLoader(BaseDataLoader):
     @dlp.log
     def next(self):
         super().next()
-        # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
-        #       `dlp.iter(self._dataset, name=self.next.__qualname__)`
-        for batch in dlp.iter(self._dataset):
+        step = 1
+        for batch in ai.dataloader.fetch.iter(self._dataset):
+            dlp.update(step=step)
+            ai.update(step=step)
+            step += 1
             yield batch
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
+        ai.update(epoch=self.epoch_number)
+
     @dlp.log
     def finalize(self):
         pass

--- a/dlio_benchmark/data_loader/tf_data_loader.py
+++ b/dlio_benchmark/data_loader/tf_data_loader.py
@@ -21,7 +21,7 @@ from dlio_benchmark.common.constants import MODULE_DATA_LOADER
 from dlio_benchmark.common.enumerations import DataLoaderType, FormatType, DatasetType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow, Profile, DLIOLogger, ai
+from dlio_benchmark.utils.utility import utcnow, Profile, DLIOLogger, dft_ai
 
 import numpy as np
 
@@ -97,14 +97,14 @@ class TFDataLoader(BaseDataLoader):
     def next(self):
         super().next()
         step = 1
-        for batch in ai.dataloader.fetch.iter(self._dataset):
+        for batch in dft_ai.dataloader.fetch.iter(self._dataset):
             dlp.update(step=step)
-            ai.update(step=step)
+            dft_ai.update(step=step)
             step += 1
             yield batch
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
-        ai.update(epoch=self.epoch_number)
+        dft_ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -14,22 +14,18 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from time import time
-import logging
 import math
 import pickle
 import torch
-from torch.utils.data import Dataset, DataLoader, RandomSampler, SequentialSampler
+from torch.utils.data import Dataset, DataLoader
 from torch.utils.data.sampler import Sampler
-import numpy as np
 
 from dlio_benchmark.common.constants import MODULE_DATA_LOADER
-from dlio_benchmark.common.enumerations import Shuffle, DatasetType, DataLoaderType
+from dlio_benchmark.common.enumerations import DatasetType, DataLoaderType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow, DLIOMPI
+from dlio_benchmark.utils.utility import utcnow, DLIOMPI, Profile, ai
 from dlio_benchmark.utils.config import ConfigArguments
-from dlio_benchmark.utils.utility import Profile
 
 dlp = Profile(MODULE_DATA_LOADER)
 
@@ -111,6 +107,7 @@ class TorchDataLoader(BaseDataLoader):
     @dlp.log_init
     def __init__(self, format_type, dataset_type, epoch_number):
         super().__init__(format_type, dataset_type, epoch_number, DataLoaderType.PYTORCH)
+
     @dlp.log
     def read(self):
         dataset = TorchDataset(self.format_type, self.dataset_type, self.epoch_number, self.num_samples,
@@ -167,14 +164,14 @@ class TorchDataLoader(BaseDataLoader):
         total = self._args.training_steps if self.dataset_type is DatasetType.TRAIN else self._args.eval_steps
         self.logger.debug(f"{utcnow()} Rank {self._args.my_rank} should read {total} batches")
         step = 1
-        # TODO: @hariharan-devarajan: change below line when we bump the dftracer version to 
-        #       `dlp.iter(self._dataset, name=self.next.__qualname__)`
-        for batch in dlp.iter(self._dataset):
-            dlp.update(step = step)
+        for batch in ai.dataloader.fetch.iter(self._dataset):
+            dlp.update(step=step)
+            ai.update(step=step)
             step += 1
             yield batch
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
+        ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -24,7 +24,7 @@ from dlio_benchmark.common.constants import MODULE_DATA_LOADER
 from dlio_benchmark.common.enumerations import DatasetType, DataLoaderType
 from dlio_benchmark.data_loader.base_data_loader import BaseDataLoader
 from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.utils.utility import utcnow, DLIOMPI, Profile, ai
+from dlio_benchmark.utils.utility import utcnow, DLIOMPI, Profile, dft_ai
 from dlio_benchmark.utils.config import ConfigArguments
 
 dlp = Profile(MODULE_DATA_LOADER)
@@ -77,7 +77,7 @@ class TorchDataset(Dataset):
         step = int(math.ceil(self.num_images_read / self.batch_size))
         self.logger.debug(f"{utcnow()} Rank {DLIOMPI.get_instance().rank()} reading {image_idx} sample")
         dlp.update(step=step)
-        ai.update(step=step)
+        dft_ai.update(step=step)
         return self.reader.read_index(image_idx, step)
 
 
@@ -164,14 +164,14 @@ class TorchDataLoader(BaseDataLoader):
         total = self._args.training_steps if self.dataset_type is DatasetType.TRAIN else self._args.eval_steps
         self.logger.debug(f"{utcnow()} Rank {self._args.my_rank} should read {total} batches")
         step = 1
-        for batch in ai.dataloader.fetch.iter(self._dataset):
+        for batch in dft_ai.dataloader.fetch.iter(self._dataset):
             dlp.update(step=step)
-            ai.update(step=step)
+            dft_ai.update(step=step)
             step += 1
             yield batch
         self.epoch_number += 1
         dlp.update(epoch=self.epoch_number)
-        ai.update(epoch=self.epoch_number)
+        dft_ai.update(epoch=self.epoch_number)
 
     @dlp.log
     def finalize(self):

--- a/dlio_benchmark/data_loader/torch_data_loader.py
+++ b/dlio_benchmark/data_loader/torch_data_loader.py
@@ -72,12 +72,12 @@ class TorchDataset(Dataset):
     def __len__(self):
         return self.num_samples
 
-    @dlp.log
     def __getitem__(self, image_idx):
         self.num_images_read += 1
         step = int(math.ceil(self.num_images_read / self.batch_size))
         self.logger.debug(f"{utcnow()} Rank {DLIOMPI.get_instance().rank()} reading {image_idx} sample")
-        dlp.update(step = step)
+        dlp.update(step=step)
+        ai.update(step=step)
         return self.reader.read_index(image_idx, step)
 
 

--- a/dlio_benchmark/framework/tf_framework.py
+++ b/dlio_benchmark/framework/tf_framework.py
@@ -15,23 +15,14 @@
    limitations under the License.
 """
 
-import os
-import logging
-from time import time, sleep
 from dlio_benchmark.common.constants import MODULE_AI_FRAMEWORK
-from dlio_benchmark.data_loader.data_loader_factory import DataLoaderFactory
-from dlio_benchmark.utils.utility import utcnow, DLIOMPI
-from dlio_benchmark.utils.utility import Profile, sleep
-from dlio_benchmark.common.error_code import ErrorCodes
+from dlio_benchmark.utils.utility import Profile, ai
 from dlio_benchmark.framework.framework import Framework
-from dlio_benchmark.reader.reader_factory import ReaderFactory
 from dlio_benchmark.profiler.profiler_factory import ProfilerFactory
-from dlio_benchmark.storage.storage_factory import StorageFactory
-from dlio_benchmark.common.enumerations import FrameworkType, Profiler, FormatType, DatasetType, MetadataType, \
+from dlio_benchmark.common.enumerations import FrameworkType, Profiler, DatasetType, MetadataType, \
     DataLoaderType
 
 import tensorflow as tf
-import tensorflow_io as tfio
 from tensorflow.python.framework import errors
 
 tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
@@ -85,7 +76,7 @@ class TFFramework(Framework):
     def trace_object(self, string, step, r):
         pass  # tf.profiler.experimental.Trace(string, step_num=step, _r=r)
 
-    @dlp.log
+    @ai.compute
     def compute(self, batch, epoch_number, step, computation_time):
         return self.model(batch, computation_time)
         # tf.function(self.model)(epoch_number, step, computation_time)

--- a/dlio_benchmark/framework/tf_framework.py
+++ b/dlio_benchmark/framework/tf_framework.py
@@ -16,7 +16,7 @@
 """
 
 from dlio_benchmark.common.constants import MODULE_AI_FRAMEWORK
-from dlio_benchmark.utils.utility import Profile, ai
+from dlio_benchmark.utils.utility import Profile, dft_ai
 from dlio_benchmark.framework.framework import Framework
 from dlio_benchmark.profiler.profiler_factory import ProfilerFactory
 from dlio_benchmark.common.enumerations import FrameworkType, Profiler, DatasetType, MetadataType, \
@@ -76,7 +76,7 @@ class TFFramework(Framework):
     def trace_object(self, string, step, r):
         pass  # tf.profiler.experimental.Trace(string, step_num=step, _r=r)
 
-    @ai.compute
+    @dft_ai.compute
     def compute(self, batch, epoch_number, step, computation_time):
         return self.model(batch, computation_time)
         # tf.function(self.model)(epoch_number, step, computation_time)

--- a/dlio_benchmark/framework/torch_framework.py
+++ b/dlio_benchmark/framework/torch_framework.py
@@ -15,23 +15,12 @@
    limitations under the License.
 """
 
-from dlio_benchmark.common.error_code import ErrorCodes
-from dlio_benchmark.common.enumerations import FormatType, FrameworkType, DatasetType, DataLoaderType
-from dlio_benchmark.data_loader.data_loader_factory import DataLoaderFactory
+from dlio_benchmark.common.enumerations import FrameworkType, DatasetType, DataLoaderType
 from dlio_benchmark.framework.framework import Framework, DummyTraceObject
 from dlio_benchmark.common.constants import MODULE_AI_FRAMEWORK
-import os
 import torch
 import functools
-import logging
-from dlio_benchmark.utils.utility import utcnow, DLIOMPI
-from dlio_benchmark.utils.utility import Profile
-
-from time import time
-
-from dlio_benchmark.reader.reader_factory import ReaderFactory
-from dlio_benchmark.storage.storage_factory import StorageFactory
-from dlio_benchmark.utils.utility import sleep
+from dlio_benchmark.utils.utility import Profile, ai, sleep
 
 HANDLED_FUNCTIONS = {}
 dlp = Profile(MODULE_AI_FRAMEWORK)
@@ -92,7 +81,7 @@ class TorchFramework(Framework):
     def trace_object(self, string, step, r):
         return DummyTraceObject(string, step, r)
 
-    @dlp.log
+    @ai.compute
     def compute(self, batch, epoch_number, step, computation_time):
         return self.model(batch, computation_time)
 

--- a/dlio_benchmark/framework/torch_framework.py
+++ b/dlio_benchmark/framework/torch_framework.py
@@ -20,7 +20,7 @@ from dlio_benchmark.framework.framework import Framework, DummyTraceObject
 from dlio_benchmark.common.constants import MODULE_AI_FRAMEWORK
 import torch
 import functools
-from dlio_benchmark.utils.utility import Profile, ai, sleep
+from dlio_benchmark.utils.utility import Profile, dft_ai, sleep
 
 HANDLED_FUNCTIONS = {}
 dlp = Profile(MODULE_AI_FRAMEWORK)
@@ -81,7 +81,7 @@ class TorchFramework(Framework):
     def trace_object(self, string, step, r):
         return DummyTraceObject(string, step, r)
 
-    @ai.compute
+    @dft_ai.compute
     def compute(self, batch, epoch_number, step, computation_time):
         return self.model(batch, computation_time)
 

--- a/dlio_benchmark/reader/csv_reader.py
+++ b/dlio_benchmark/reader/csv_reader.py
@@ -17,7 +17,7 @@
 import pandas as pd
 
 from dlio_benchmark.common.constants import MODULE_DATA_READER
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, dft_ai
 from dlio_benchmark.reader.reader_handler import FormatReader
 
 dlp = Profile(MODULE_DATA_READER)
@@ -46,6 +46,7 @@ class CSVReader(FormatReader):
         super().get_sample(filename, sample_index)
         image = self.open_file_map[filename][sample_index]
         dlp.update(image_size=image.nbytes)
+        dft_ai.update(image_size=image.nbytes)
 
     def next(self):
         for batch in super().next():

--- a/dlio_benchmark/reader/dali_image_reader.py
+++ b/dlio_benchmark/reader/dali_image_reader.py
@@ -14,18 +14,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import math
-import logging
-from time import time
-import numpy as np
-
 import nvidia.dali.fn as fn
 from dlio_benchmark.common.constants import MODULE_DATA_READER
 from dlio_benchmark.reader.reader_handler import FormatReader
 from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.common.enumerations import DatasetType, Shuffle
-import nvidia.dali.tfrecord as tfrec
-from dlio_benchmark.utils.utility import PerfTrace, Profile
+from dlio_benchmark.common.enumerations import Shuffle
+from dlio_benchmark.utils.utility import Profile
 
 dlp = Profile(MODULE_DATA_READER)
 

--- a/dlio_benchmark/reader/dali_npy_reader.py
+++ b/dlio_benchmark/reader/dali_npy_reader.py
@@ -14,18 +14,13 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import math
-import logging
-from time import time
-import numpy as np
 
 import nvidia.dali.fn as fn
 from dlio_benchmark.common.constants import MODULE_DATA_READER
 from dlio_benchmark.reader.reader_handler import FormatReader
 from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.common.enumerations import DatasetType, Shuffle
-import nvidia.dali.tfrecord as tfrec
-from dlio_benchmark.utils.utility import PerfTrace, Profile
+from dlio_benchmark.common.enumerations import Shuffle
+from dlio_benchmark.utils.utility import Profile
 
 dlp = Profile(MODULE_DATA_READER)
 
@@ -59,7 +54,7 @@ class DaliNPYReader(FormatReader):
             prefetch_size = self._args.prefetch_size
 
         stick_to_shard = True
-        if random_shuffle == True:
+        if random_shuffle:
             seed_change_epoch = False
         if seed_change_epoch:
             stick_to_shard = False
@@ -95,6 +90,7 @@ class DaliNPYReader(FormatReader):
     @dlp.log
     def finalize(self):
         pass
+
     def is_index_based(self):
         return False
 

--- a/dlio_benchmark/reader/dali_tfrecord_reader.py
+++ b/dlio_benchmark/reader/dali_tfrecord_reader.py
@@ -14,21 +14,15 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import os.path
+import os
 
-import math
-import logging
-from time import time
-import numpy as np
-
-import nvidia
 import nvidia.dali.fn as fn
 from dlio_benchmark.common.constants import MODULE_DATA_READER
 from dlio_benchmark.reader.reader_handler import FormatReader
 from dlio_benchmark.utils.utility import utcnow
 from dlio_benchmark.common.enumerations import DatasetType, Shuffle
 import nvidia.dali.tfrecord as tfrec
-from dlio_benchmark.utils.utility import PerfTrace, Profile
+from dlio_benchmark.utils.utility import Profile
 
 dlp = Profile(MODULE_DATA_READER)
 

--- a/dlio_benchmark/reader/hdf5_reader.py
+++ b/dlio_benchmark/reader/hdf5_reader.py
@@ -44,12 +44,13 @@ class HDF5Reader(FormatReader):
         super().get_sample(filename, sample_index)
         image = self.open_file_map[filename]['records'][sample_index]
         dlp.update(image_size=image.nbytes)
+        dft_ai.update(image_size=image.nbytes)
 
     def next(self):
         for batch in super().next():
             yield batch
 
-    @dft_ai.data.item
+    @dlp.log
     def read_index(self, image_idx, step):
         return super().read_index(image_idx, step)
 

--- a/dlio_benchmark/reader/hdf5_reader.py
+++ b/dlio_benchmark/reader/hdf5_reader.py
@@ -19,7 +19,7 @@ import logging
 import h5py
 
 from dlio_benchmark.common.constants import MODULE_DATA_READER
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, ai
 from dlio_benchmark.reader.reader_handler import FormatReader
 
 dlp = Profile(MODULE_DATA_READER)
@@ -51,7 +51,7 @@ class HDF5Reader(FormatReader):
         for batch in super().next():
             yield batch
 
-    @dlp.log
+    @ai.data.item
     def read_index(self, image_idx, step):
         return super().read_index(image_idx, step)
 

--- a/dlio_benchmark/reader/hdf5_reader.py
+++ b/dlio_benchmark/reader/hdf5_reader.py
@@ -14,12 +14,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import logging
-
 import h5py
 
 from dlio_benchmark.common.constants import MODULE_DATA_READER
-from dlio_benchmark.utils.utility import Profile, ai
+from dlio_benchmark.utils.utility import Profile, dft_ai
 from dlio_benchmark.reader.reader_handler import FormatReader
 
 dlp = Profile(MODULE_DATA_READER)
@@ -51,7 +49,7 @@ class HDF5Reader(FormatReader):
         for batch in super().next():
             yield batch
 
-    @ai.data.item
+    @dft_ai.data.item
     def read_index(self, image_idx, step):
         return super().read_index(image_idx, step)
 

--- a/dlio_benchmark/reader/image_reader.py
+++ b/dlio_benchmark/reader/image_reader.py
@@ -22,7 +22,7 @@ from PIL import Image
 from dlio_benchmark.common.constants import MODULE_DATA_READER
 from dlio_benchmark.reader.reader_handler import FormatReader
 from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, dft_ai
 
 dlp = Profile(MODULE_DATA_READER)
 
@@ -50,6 +50,7 @@ class ImageReader(FormatReader):
         super().get_sample(filename, sample_index)
         image = self.open_file_map[filename]
         dlp.update(image_size=image.nbytes)
+        dft_ai.update(image_size=image.nbytes)
 
     def next(self):
         for batch in super().next():

--- a/dlio_benchmark/reader/indexed_binary_mmap_reader.py
+++ b/dlio_benchmark/reader/indexed_binary_mmap_reader.py
@@ -14,15 +14,12 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import logging
-
 import numpy as np
-import struct
 
 from dlio_benchmark.common.constants import MODULE_DATA_READER
 from dlio_benchmark.common.enumerations import DataLoaderSampler
 from dlio_benchmark.reader.reader_handler import FormatReader
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, dft_ai
 
 dlp = Profile(MODULE_DATA_READER)
 
@@ -74,9 +71,6 @@ class IndexedBinaryMMapReader(FormatReader):
             for global_sample_idx, (filename, sample_index) in self.global_index_map.items():
                 self.load_index_file(global_sample_idx, filename, sample_index)
 
-
-
-
     @dlp.log
     def open(self, filename):
         super().open(filename)        
@@ -85,7 +79,6 @@ class IndexedBinaryMMapReader(FormatReader):
     @dlp.log
     def close(self, filename):
         super().close(filename)
-        
 
     @dlp.log
     def get_sample(self, filename, sample_index):
@@ -95,12 +88,14 @@ class IndexedBinaryMMapReader(FormatReader):
         size = self.file_map_ibr[filename][1][sample_index]
         image = buffer[offset:offset+size]
         dlp.update(image_size=size)
+        dft_ai.update(image_size=size)
 
     def next(self):
         for batch in super().next():
             yield batch
 
     @dlp.log
+    @dft_ai.data.item
     def read_index(self, image_idx, step):
         filename, sample_index = self.global_index_map[image_idx]
         self.get_sample(filename, sample_index)

--- a/dlio_benchmark/reader/reader_handler.py
+++ b/dlio_benchmark/reader/reader_handler.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from dlio_benchmark.common.enumerations import DatasetType, ReadType
 from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile, sleep, ai
+from dlio_benchmark.utils.utility import Profile, sleep, dft_ai
 from dlio_benchmark.utils.config import ConfigArguments
 from dlio_benchmark.common.constants import MODULE_DATA_READER
 
@@ -69,7 +69,7 @@ class FormatReader(ABC):
         return
 
     @abstractmethod
-    @ai.data.item
+    @dft_ai.data.item
     def next(self):
         batch = []
         image_processed = 0
@@ -101,7 +101,7 @@ class FormatReader(ABC):
                 break
 
     @abstractmethod
-    @ai.data.item
+    @dft_ai.data.item
     def read_index(self, global_sample_idx, step):
         self.step = step
         self.image_idx = global_sample_idx

--- a/dlio_benchmark/reader/reader_handler.py
+++ b/dlio_benchmark/reader/reader_handler.py
@@ -16,20 +16,13 @@
 """
 from abc import ABC, abstractmethod
 
-from dlio_benchmark.common.enumerations import FrameworkType, Shuffle, FileAccess, DatasetType, MetadataType, DataLoaderType, \
-    ReadType
-from dlio_benchmark.framework.framework_factory import FrameworkFactory
-from dlio_benchmark.storage.storage_factory import StorageFactory
-from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile
-from dlio_benchmark.utils.config import ConfigArguments
 import numpy as np
-import os
-import math
-import logging
-import glob
+
+from dlio_benchmark.common.enumerations import DatasetType, ReadType
+from dlio_benchmark.utils.utility import utcnow
+from dlio_benchmark.utils.utility import Profile, sleep, ai
+from dlio_benchmark.utils.config import ConfigArguments
 from dlio_benchmark.common.constants import MODULE_DATA_READER
-from dlio_benchmark.utils.utility import sleep
 
 dlp = Profile(MODULE_DATA_READER)
 
@@ -76,8 +69,8 @@ class FormatReader(ABC):
         return
 
     @abstractmethod
+    @ai.data.item
     def next(self):
-        batch_size = self._args.batch_size if self.dataset_type is DatasetType.TRAIN else self._args.batch_size_eval
         batch = []
         image_processed = 0
         self.step = 1
@@ -108,6 +101,7 @@ class FormatReader(ABC):
                 break
 
     @abstractmethod
+    @ai.data.item
     def read_index(self, global_sample_idx, step):
         self.step = step
         self.image_idx = global_sample_idx

--- a/dlio_benchmark/reader/synthetic_reader.py
+++ b/dlio_benchmark/reader/synthetic_reader.py
@@ -14,11 +14,11 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-import numpy as np
 
 from dlio_benchmark.common.constants import MODULE_DATA_READER
+from dlio_benchmark.common.enumerations import DatasetType
 from dlio_benchmark.reader.reader_handler import FormatReader
-from dlio_benchmark.utils.utility import Profile
+from dlio_benchmark.utils.utility import Profile, dft_ai
 
 dlp = Profile(MODULE_DATA_READER)
 
@@ -46,15 +46,25 @@ class SyntheticReader(FormatReader):
 
     @dlp.log
     def next(self):
+        total = self._args.training_steps if self.dataset_type is DatasetType.TRAIN else self._args.eval_steps
+        step = 1
         while True:
+            dft_ai.data.item.start()
             batch = []
             for i in range(self.batch_size):
                 batch.append(self._args.resized_image)
+            dft_ai.data.item.stop()
             yield batch
+            step += 1
+            if step > total:
+                break
+            dft_ai.data.item.start()
 
     @dlp.log
+    @dft_ai.data.item
     def read_index(self, image_idx, step):
         dlp.update(step=step)
+        dft_ai.update(step=step)
         return self._args.resized_image
 
     @dlp.log

--- a/dlio_benchmark/reader/tf_reader.py
+++ b/dlio_benchmark/reader/tf_reader.py
@@ -15,13 +15,10 @@
    limitations under the License.
 """
 import math
-import logging
-from time import time
 
 from dlio_benchmark.common.constants import MODULE_DATA_READER
-from dlio_benchmark.utils.utility import utcnow
-from dlio_benchmark.utils.utility import Profile
-from dlio_benchmark.common.enumerations import DatasetType, Shuffle
+from dlio_benchmark.utils.utility import utcnow, Profile
+from dlio_benchmark.common.enumerations import Shuffle
 from dlio_benchmark.reader.reader_handler import FormatReader
 import tensorflow as tf
 
@@ -109,6 +106,7 @@ class TFReader(FormatReader):
 
         self._dataset = self._dataset.repeat()
         total = math.floor(len(self._file_list)/self._args.comm_size / self.batch_size * self._args.num_samples_per_file)
+        
         return self._dataset.take(total*self._args.epochs).prefetch(buffer_size=self._args.prefetch_size)
     
     @dlp.log

--- a/dlio_benchmark/utils/statscounter.py
+++ b/dlio_benchmark/utils/statscounter.py
@@ -245,6 +245,7 @@ class StatsCounter(object):
             self.output[epoch]['host_meminfo'] = lines_to_dict(open("/proc/meminfo", "r").read())
 
     def end_train(self, epoch, steps):
+        self.logger.output(f"DData {self.output[epoch]['au']}")
         au = np.array([self.output[epoch]['au'][k] for k in self.output[epoch]['au']])
         throughput = np.array([self.output[epoch]['throughput'][k] for k in self.output[epoch]['throughput']])
         steps = np.array([len(self.output[epoch]['proc'][k]) for k in self.output[epoch]['throughput']])
@@ -313,8 +314,8 @@ class StatsCounter(object):
         self.start_timestamp = time()
         self.output[epoch]['load'][f'block{block}'] = []
         self.output[epoch]['proc'][f'block{block}'] = []
-        self.output[epoch]['throughput'][f'block{block}'] = []
-        self.output[epoch]['au'][f'block{block}'] = []
+        self.output[epoch]['throughput'][f'block{block}'] = 0.0
+        self.output[epoch]['au'][f'block{block}'] = 0.0
         self.output[epoch]['compute'][f'block{block}'] = []
         ts = utcnow()
         self.per_epoch_stats[epoch][f'block{block}'] = {

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -35,7 +35,7 @@ try:
     from dftracer.logger import (
         dftracer as PerfTrace,
         dft_fn as Profile,
-        ai,
+        ai as dft_ai,
         DFTRACER_ENABLE
     )
 except ImportError:  # noqa: E722
@@ -80,7 +80,7 @@ except ImportError:  # noqa: E722
     Profile = _NoOp
     PerfTrace = _NoOp
     dftracer = _NoOp
-    ai = _NoOp()
+    dft_ai = _NoOp()
 
     DFTRACER_ENABLE = False
 

--- a/dlio_benchmark/utils/utility.py
+++ b/dlio_benchmark/utils/utility.py
@@ -22,13 +22,15 @@ from time import time, sleep as base_sleep
 from functools import wraps
 import threading
 import json
-from typing import Any, Callable, Dict, List, Optional, cast, Iterator, TypeVar, overload
-
-import numpy as np
-import psutil
+import tracemalloc
+from time import perf_counter
 import socket
-# UTC timestamp format with microsecond precision
+
+import psutil
+import numpy as np
+
 from dlio_benchmark.common.enumerations import MPIState
+
 try:
     from dftracer.logger import (
         dftracer as PerfTrace,
@@ -36,7 +38,7 @@ try:
         ai,
         DFTRACER_ENABLE
     )
-except ImportError:
+except ImportError:  # noqa: E722
     # Compact fallback classes when dftracer is not available
     # fmt: off
     class _NoOp:
@@ -247,10 +249,6 @@ def timeit(func):
         return x, "%10.10f" % begin, "%10.10f" % end, os.getpid()
 
     return wrapper
-
-
-import tracemalloc
-from time import perf_counter
 
 
 def measure_performance(func):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ x86_deps = [
     f"hydra-core>={HYDRA_VERSION}",
     "nvidia-dali-cuda120>=1.34.0",
     "tensorflow>=2.13.1",
-    "tensorflow_io>=0.33.0",
     "torch>=2.2.0",
     "torchaudio",
     "torchvision",
@@ -41,7 +40,7 @@ else:
 extras = {
     "test": test_deps,
     "dftracer": [
-        "pydftracer==1.0.11",
+        "pydftracer @ git+https://github.com/LLNL/dftracer.git@b64cd2a800d6d90c7777405569a6cd2b8b0487c4",
     ],
 }
 

--- a/tests/dlio_ai_logging_test.py
+++ b/tests/dlio_ai_logging_test.py
@@ -17,7 +17,6 @@ limitations under the License.
 
 #!/usr/bin/env python
 import uuid
-import shutil
 import pytest
 import os
 import glob
@@ -37,7 +36,7 @@ comm = MPI.COMM_WORLD
 
 config_dir = os.path.dirname(dlio_benchmark.__file__) + "/configs/"
 
-def run_benchmark(cfg, storage_root="./"):
+def run_benchmark(cfg):
     comm.Barrier()
     ConfigArguments.reset()
     benchmark = DLIOBenchmark(cfg["workload"])
@@ -45,6 +44,10 @@ def run_benchmark(cfg, storage_root="./"):
     benchmark.run()
     benchmark.finalize()
     return benchmark
+
+def delete_folder(path):
+    import shutil
+    shutil.rmtree(path, ignore_errors=True)
 
 
 @pytest.fixture
@@ -59,19 +62,18 @@ def setup_test_env():
 
     if comm.rank == 0:
         if os.path.exists(storage_root):
-            shutil.rmtree(storage_root)
+            delete_folder(storage_root)
         os.makedirs(storage_root, exist_ok=True)
 
     comm.Barrier()
     yield storage_root
-    # comm.Barrier()
-    # if comm.rank == 0:
-    #     shutil.rmtree(storage_root, ignore_errors=True)
     comm.Barrier()
-    DLIOMPI.get_instance().finalize()
+    if comm.rank == 0:
+        delete_folder(storage_root)
+    comm.Barrier()
 
 def check_ai_events(path):
-    counter = Counter(root=0, compute=0, data_item=0, fetch_iter=0, train=0, eval=0, epoch=0)
+    counter = Counter(root=0, compute=0, data_item=0, fetch_iter=0, train=0, eval=0, epoch=0, ckpt_capture=0, ckpt_restart=0)
     with open(path, mode="r") as f:
         for line in f:
             if "[" in line or "]" in line:
@@ -84,6 +86,10 @@ def check_ai_events(path):
                 counter["data_item"] += 1
             if '"cat":"dataloader"' in line and '"name":"fetch.iter"' in line:
                 counter["fetch_iter"] += 1
+            if '"cat":"checkpoint"' in line and '"name":"capture"' in line:
+                counter["ckpt_capture"] += 1
+            if '"cat":"checkpoint"' in line and '"name":"restart"' in line:
+                counter["ckpt_restart"] += 1
             if '"cat":"pipeline"' in line and '"name":"train"' in line:
                 counter["train"] += 1
             if '"cat":"pipeline"' in line and '"name":"evaluate"' in line:
@@ -93,12 +99,16 @@ def check_ai_events(path):
     return counter
 
 @pytest.mark.timeout(60, method="thread")
-@pytest.mark.parametrize("framework", ["pytorch", "tensorflow"])
-def test_ai_logging_train(setup_test_env, framework):
+@pytest.mark.parametrize("framework, num_data, batch_size", [
+    (framework, num_data, batch_size)
+    for framework in ["pytorch", "tensorflow"]
+    for num_data in [9, 10]  # even and odd
+    for batch_size in [2, 3]  # even and odd
+])
+def test_ai_logging_train(setup_test_env, framework, num_data, batch_size):
     storage_root = setup_test_env
     num_epochs = 2
-    batch_size = 2
-    num_data_pp = 8
+    num_data_pp = num_data
     total_data = num_data_pp * comm.size
     with initialize_config_dir(version_base=None, config_dir=config_dir):
         cfg = compose(
@@ -122,10 +132,10 @@ def test_ai_logging_train(setup_test_env, framework):
         run_benchmark(cfg)
 
     paths = glob.glob(os.path.join(storage_root, "*.pfw"))
-    if len(paths) == 0:
-        pytest.fail("No pfw files found")
 
-    count = check_ai_events(path=paths[0])
+    assert len(paths) > 0, "No pfw files found"
+
+    count = check_ai_events(path=paths[comm.rank % len(paths)])
 
     if comm.rank == 0:
         print("AI events count:", count)
@@ -135,15 +145,29 @@ def test_ai_logging_train(setup_test_env, framework):
     assert count["epoch"]      == num_epochs
     assert count["train"]      == num_epochs
     assert count["eval"]       == 0
+    # @ray: we are using // because in DLIO we always drop last when
+    # number of data is not evenly divisible by the batch size
     assert count["fetch_iter"] == num_epochs * (num_data_pp // batch_size)
     assert count["compute"]    == num_epochs * (num_data_pp // batch_size)
+    # @ray: this is the tricky part, we run data fetching on background
+    # (e.g. using parallel workers). using exact number will be difficult
+    # we use relax comparison instead.
+    assert count["data_item"]  >= num_epochs * (num_data_pp // batch_size)
+
+    assert count["ckpt_capture"] == 0
+    assert count["ckpt_restart"] == 0
 
 @pytest.mark.timeout(60, method="thread")
-@pytest.mark.parametrize("framework, step", [("pytorch", 3), ("tensorflow", 3)])
-def test_ai_logging_train_with_step(setup_test_env, framework, step):
+@pytest.mark.parametrize("framework, step, read_threads", [
+    (framework, step, read_threads)
+    for framework in ["pytorch", "tensorflow"]
+    for step in [2, 3]  # even and odd
+    for read_threads in [2, 3]  # even and odd
+])
+def test_ai_logging_train_with_step(setup_test_env, framework, step, read_threads):
     storage_root = setup_test_env
     num_epochs = 2
-    batch_size = 1
+    batch_size = 2
     num_data_pp = 8
     total_data = num_data_pp * comm.size
     with initialize_config_dir(version_base=None, config_dir=config_dir):
@@ -164,15 +188,16 @@ def test_ai_logging_train_with_step(setup_test_env, framework, step):
                 f"++workload.reader.batch_size={batch_size}",
                 f"++workload.train.epochs={num_epochs}",
                 f"++workload.train.total_training_steps={step}",
+                f"++workload.reader.read_threads={read_threads}",
             ],
         )
         run_benchmark(cfg)
 
     paths = glob.glob(os.path.join(storage_root, "*.pfw"))
-    if len(paths) == 0:
-        pytest.fail("No pfw files found")
 
-    count = check_ai_events(path=paths[0])
+    assert len(paths) > 0, "No pfw files found"
+
+    count = check_ai_events(path=paths[comm.rank % len(paths)])
 
     if comm.rank == 0:
         print("AI events count:", count)
@@ -182,8 +207,17 @@ def test_ai_logging_train_with_step(setup_test_env, framework, step):
     assert count["epoch"]      == num_epochs
     assert count["train"]      == num_epochs
     assert count["eval"]       == 0
-    assert count["fetch_iter"] == num_epochs * (step // batch_size)
-    assert count["compute"]    == num_epochs * (step // batch_size)
+    assert count["fetch_iter"] == num_epochs * step
+    assert count["compute"]    == num_epochs * step
+
+    # @ray: we relaxed this constraint to be ">=" since
+    # the dataloader runs in parallel to the main training loop.
+    # thus we may see more data items being processed in the 
+    # background
+    assert count["data_item"] >= num_epochs * step
+
+    assert count["ckpt_capture"] == 0
+    assert count["ckpt_restart"] == 0
 
 
 @pytest.mark.timeout(60, method="thread")
@@ -216,18 +250,223 @@ def test_ai_logging_with_eval(setup_test_env, framework):
         run_benchmark(cfg)
 
     paths = glob.glob(os.path.join(storage_root, "*.pfw"))
-    if len(paths) == 0:
-        pytest.fail("No pfw files found")
+    assert len(paths) > 0, "No pfw files found"
 
-    count = check_ai_events(path=paths[0])
+    count = check_ai_events(path=paths[comm.rank % len(paths)])
 
     if comm.rank == 0:
         print("AI events count:", count)
 
     # check single file from single rank only
+    assert count["root"]         == 1
+    assert count["epoch"]        == num_epochs
+    assert count["train"]        == num_epochs
+    assert count["eval"]         == num_epochs
+    assert count["fetch_iter"]   == 2 * num_epochs * (num_data_pp // batch_size)
+    assert count["compute"]      == 2 * num_epochs * (num_data_pp // batch_size)
+    assert count["data_item"]    == 2 * num_epochs * num_data_pp
+    assert count["ckpt_capture"] == 0
+    assert count["ckpt_restart"] == 0
+
+@pytest.mark.timeout(60, method="thread")
+@pytest.mark.parametrize("framework, fmt", [
+    (framework, fmt) 
+    for framework in ["pytorch", "tensorflow"]
+    for fmt in ["hdf5", "npy", "npz", "tfrecord", "csv", "jpeg", "png", "indexed_binary", "mmap_indexed_binary", "synthetic"]
+    if not (fmt == "tfrecord" and framework == "pytorch")  # Exclude tfrecord + pytorch
+])
+def test_ai_logging_with_reader(setup_test_env, framework, fmt):
+    storage_root = setup_test_env
+    num_epochs = 2
+    batch_size = 1
+    num_data_pp = 8
+    total_data = num_data_pp * comm.size
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.train=True",
+                "++workload.workflow.evaluation=True",
+                "++workload.workflow.generate_data=True",
+                f"++workload.output.folder={storage_root}",
+                f"++workload.dataset.data_folder={storage_root}/data",
+                f"++workload.dataset.num_files_train={total_data}",
+                f"++workload.dataset.num_files_eval={total_data}",
+                "++workload.dataset.num_subfolders_train=0",
+                "++workload.dataset.num_subfolders_eval=0",
+                f"++workload.reader.batch_size={batch_size}",
+                f"++workload.train.epochs={num_epochs}",
+                f"++workload.dataset.format={fmt}",
+            ],
+        )
+        run_benchmark(cfg)
+
+    paths = glob.glob(os.path.join(storage_root, "*.pfw"))
+
+    assert len(paths) > 0, "No pfw files found"
+
+    count = check_ai_events(path=paths[comm.rank % len(paths)])
+
+    if comm.rank == 0:
+        print("AI events count:", count)
+
     assert count["root"]       == 1
     assert count["epoch"]      == num_epochs
     assert count["train"]      == num_epochs
     assert count["eval"]       == num_epochs
     assert count["fetch_iter"] == 2 * num_epochs * (num_data_pp // batch_size)
     assert count["compute"]    == 2 * num_epochs * (num_data_pp // batch_size)
+    if fmt == "tfrecord":
+        assert count["data_item"] == 0
+    else:
+        assert count["data_item"] == 2 * num_epochs * num_data_pp
+
+    assert count["ckpt_capture"] == 0
+    assert count["ckpt_restart"] == 0
+
+# @ray: future note: it seems DLIO hasn't implemented the all_ranks checkpointing yet
+# this test suite is only for checkpointing on rank_zero only
+# @todo: add test-cases to test all_ranks by adding ++workload.checkpoint.type=<VALUE>
+@pytest.mark.timeout(60, method="thread")
+@pytest.mark.parametrize("framework, epoch_per_ckpt, steps_per_ckpt", [
+    (framework, epoch_per_ckpt, steps_per_ckpt)
+    for framework in ["pytorch", "tensorflow"]
+    for epoch_per_ckpt in [1, 2]
+    for steps_per_ckpt in ["na", 1, 2]
+])
+def test_ai_logging_train_with_checkpoint(setup_test_env, framework, epoch_per_ckpt, steps_per_ckpt):
+    storage_root = setup_test_env
+    num_epochs = 2
+    batch_size = 1
+    num_data_pp = 4
+    total_data = num_data_pp * comm.size
+    if steps_per_ckpt == "na":
+        steps_per_ckpt = -1
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.generate_data=True",
+                "++workload.workflow.train=True",
+                "++workload.workflow.evaluation=False",
+                "++workload.workflow.checkpoint=True",
+                f"++workload.output.folder={storage_root}",
+                f"++workload.dataset.data_folder={storage_root}/data",
+                f"++workload.dataset.num_files_train={total_data}",
+                "++workload.dataset.num_files_eval=0",
+                "++workload.dataset.num_subfolders_train=0",
+                "++workload.dataset.num_subfolders_eval=0",
+                f"++workload.train.epochs={num_epochs}",
+                f"++workload.reader.batch_size={batch_size}",
+                f"++workload.checkpoint.epochs_between_checkpoints={epoch_per_ckpt}",
+                f"++workload.checkpoint.steps_between_checkpoints={steps_per_ckpt}",
+            ],
+        )
+        run_benchmark(cfg)
+
+    paths = glob.glob(os.path.join(storage_root, "*.pfw"))
+
+    assert len(paths) > 0, "No pfw files found"
+
+    # find trace-{RANK} in paths
+    chosen_path = [p for p in paths if f"trace-{comm.rank}" in p]
+    assert len(chosen_path) == 1
+    path = chosen_path[0]
+
+    count = check_ai_events(path=path)
+
+    print(f"[RANK-{comm.rank}] AI events count: {count}")
+
+    assert count["root"]       == 1
+    assert count["epoch"]      == num_epochs
+    assert count["train"]      == num_epochs
+    assert count["eval"]       == 0
+    assert count["fetch_iter"] == num_epochs * (num_data_pp // batch_size)
+    assert count["compute"]    == num_epochs * (num_data_pp // batch_size)
+    assert count["data_item"]  >= num_epochs * (num_data_pp // batch_size)
+
+    # @ray: this assertion below is only for rank 0
+    # @todo: when DLIO supports all_ranks checkpointing, adjust this
+    ckpt_capture = 0
+    if comm.rank == 0:
+        ckpt_capture = count["ckpt_capture"]
+    else:
+        ckpt_capture = None
+
+    ckpt_capture = comm.bcast(ckpt_capture, root=0)
+    assert ckpt_capture is not None
+    assert ckpt_capture == num_epochs * epoch_per_ckpt * (steps_per_ckpt if steps_per_ckpt != -1 else 1)
+    assert count["ckpt_restart"] == 0
+
+@pytest.mark.timeout(60, method="thread")
+@pytest.mark.parametrize("framework, num_checkpoint_write, num_checkpoint_read", [
+    (framework, num_checkpoint_write, num_checkpoint_read)
+    for framework in ["pytorch", "tensorflow"]
+    for num_checkpoint_write in [3, 4]
+    for num_checkpoint_read in [1, 2, 3]
+])
+def test_ai_logging_train_with_checkpoint_only(setup_test_env, framework, num_checkpoint_write, num_checkpoint_read):
+    storage_root = setup_test_env
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.generate_data=False",
+                "++workload.workflow.train=False",
+                "++workload.workflow.evaluation=False",
+                "++workload.workflow.checkpoint=True",
+                f"++workload.output.folder={storage_root}",
+                f"++workload.dataset.data_folder={storage_root}/data",
+                "++workload.dataset.num_files_eval=0",
+                "++workload.dataset.num_subfolders_train=0",
+                "++workload.dataset.num_subfolders_eval=0",
+                f"++workload.checkpoint.checkpoint_folder={storage_root}/checkpoint",
+                f"++workload.checkpoint.num_checkpoints_write={num_checkpoint_write}",
+                f"++workload.checkpoint.num_checkpoints_read={num_checkpoint_read}",
+            ],
+        )
+        run_benchmark(cfg)
+
+    paths = glob.glob(os.path.join(storage_root, "*.pfw"))
+    assert len(paths) == 0, "No pfw files found"
+
+    # find trace-{RANK} in paths
+    chosen_path = [p for p in paths if f"trace-{comm.rank}" in p]
+    assert len(chosen_path) == 1
+    path = chosen_path[0]
+
+    count = check_ai_events(path=path)
+
+    print(f"[RANK-{comm.rank}] AI events count: {count}")
+
+    assert count["root"]       == 1
+    assert count["epoch"]      == 0
+    assert count["train"]      == 0
+    assert count["eval"]       == 0
+    assert count["fetch_iter"] == 0
+    assert count["data_item"]  >= 0
+
+    # @ray: this assertion below is only for rank 0
+    # @todo: when DLIO supports all_ranks checkpointing, adjust this
+    ckpt_capture = 0
+    ckpt_restart = 0
+    if comm.rank == 0:
+        ckpt_capture = count["ckpt_capture"]
+        ckpt_restart = count["ckpt_restart"]
+    else:
+        ckpt_capture = None
+        ckpt_restart = None
+
+    ckpt_capture = comm.bcast(ckpt_capture, root=0)
+    ckpt_restart = comm.bcast(ckpt_restart, root=0)
+    assert ckpt_capture is not None
+    assert ckpt_restart is not None
+    assert ckpt_capture == num_checkpoint_write
+    assert ckpt_restart == num_checkpoint_read
+    assert count["compute"] == num_checkpoint_write + num_checkpoint_read

--- a/tests/dlio_ai_logging_test.py
+++ b/tests/dlio_ai_logging_test.py
@@ -1,0 +1,233 @@
+"""
+Copyright (c) 2022, UChicago Argonne, LLC
+All Rights Reserved
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+#!/usr/bin/env python
+import uuid
+import shutil
+import pytest
+import os
+import glob
+from datetime import datetime
+from collections import Counter
+
+from mpi4py import MPI
+
+from hydra import initialize_config_dir, compose
+
+from dlio_benchmark.main import DLIOBenchmark
+from dlio_benchmark.utils.config import ConfigArguments
+from dlio_benchmark.utils.utility import DLIOMPI
+import dlio_benchmark
+
+comm = MPI.COMM_WORLD
+
+config_dir = os.path.dirname(dlio_benchmark.__file__) + "/configs/"
+
+def run_benchmark(cfg, storage_root="./"):
+    comm.Barrier()
+    ConfigArguments.reset()
+    benchmark = DLIOBenchmark(cfg["workload"])
+    benchmark.initialize()
+    benchmark.run()
+    benchmark.finalize()
+    return benchmark
+
+
+@pytest.fixture
+def setup_test_env():
+    DLIOMPI.get_instance().initialize()
+    if comm.rank == 0:
+        now = datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
+        storage_root = os.path.join("outputs", f"{now}-{str(uuid.uuid4())}")
+    else:
+        storage_root = None
+    storage_root = comm.bcast(storage_root, root=0)
+
+    if comm.rank == 0:
+        if os.path.exists(storage_root):
+            shutil.rmtree(storage_root)
+        os.makedirs(storage_root, exist_ok=True)
+
+    comm.Barrier()
+    yield storage_root
+    # comm.Barrier()
+    # if comm.rank == 0:
+    #     shutil.rmtree(storage_root, ignore_errors=True)
+    comm.Barrier()
+    DLIOMPI.get_instance().finalize()
+
+def check_ai_events(path):
+    counter = Counter(root=0, compute=0, data_item=0, fetch_iter=0, train=0, eval=0, epoch=0)
+    with open(path, mode="r") as f:
+        for line in f:
+            if "[" in line or "]" in line:
+                continue
+            if '"cat":"ai_root"' in line and '"name":"ai_root"' in line:
+                counter["root"] += 1
+            if '"cat":"compute"' in line and '"name":"compute"' in line:
+                counter["compute"] += 1
+            if '"cat":"data"' in line and '"name":"item"' in line:
+                counter["data_item"] += 1
+            if '"cat":"dataloader"' in line and '"name":"fetch.iter"' in line:
+                counter["fetch_iter"] += 1
+            if '"cat":"pipeline"' in line and '"name":"train"' in line:
+                counter["train"] += 1
+            if '"cat":"pipeline"' in line and '"name":"evaluate"' in line:
+                counter["eval"] += 1
+            if '"cat":"pipeline"' in line and '"name":"epoch.block"' in line:
+                counter["epoch"] += 1
+    return counter
+
+@pytest.mark.timeout(60, method="thread")
+@pytest.mark.parametrize("framework", ["pytorch", "tensorflow"])
+def test_ai_logging_train(setup_test_env, framework):
+    storage_root = setup_test_env
+    num_epochs = 2
+    batch_size = 2
+    num_data_pp = 8
+    total_data = num_data_pp * comm.size
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.train=True",
+                "++workload.workflow.evaluation=False",
+                "++workload.workflow.generate_data=True",
+                f"++workload.output.folder={storage_root}",
+                f"++workload.dataset.data_folder={storage_root}/data",
+                f"++workload.dataset.num_files_train={total_data}",
+                "++workload.dataset.num_files_eval=0",
+                "++workload.dataset.num_subfolders_train=0",
+                "++workload.dataset.num_subfolders_eval=0",
+                f"++workload.train.epochs={num_epochs}",
+                f"++workload.reader.batch_size={batch_size}"
+            ],
+        )
+        run_benchmark(cfg)
+
+    paths = glob.glob(os.path.join(storage_root, "*.pfw"))
+    if len(paths) == 0:
+        pytest.fail("No pfw files found")
+
+    count = check_ai_events(path=paths[0])
+
+    if comm.rank == 0:
+        print("AI events count:", count)
+
+    # check single file from single rank only
+    assert count["root"]       == 1
+    assert count["epoch"]      == num_epochs
+    assert count["train"]      == num_epochs
+    assert count["eval"]       == 0
+    assert count["fetch_iter"] == num_epochs * (num_data_pp // batch_size)
+    assert count["compute"]    == num_epochs * (num_data_pp // batch_size)
+
+@pytest.mark.timeout(60, method="thread")
+@pytest.mark.parametrize("framework, step", [("pytorch", 3), ("tensorflow", 3)])
+def test_ai_logging_train_with_step(setup_test_env, framework, step):
+    storage_root = setup_test_env
+    num_epochs = 2
+    batch_size = 1
+    num_data_pp = 8
+    total_data = num_data_pp * comm.size
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.train=True",
+                "++workload.workflow.evaluation=False",
+                "++workload.workflow.generate_data=True",
+                f"++workload.output.folder={storage_root}",
+                f"++workload.dataset.data_folder={storage_root}/data",
+                f"++workload.dataset.num_files_train={total_data}",
+                "++workload.dataset.num_files_eval=0",
+                "++workload.dataset.num_subfolders_train=0",
+                "++workload.dataset.num_subfolders_eval=0",
+                f"++workload.reader.batch_size={batch_size}",
+                f"++workload.train.epochs={num_epochs}",
+                f"++workload.train.total_training_steps={step}",
+            ],
+        )
+        run_benchmark(cfg)
+
+    paths = glob.glob(os.path.join(storage_root, "*.pfw"))
+    if len(paths) == 0:
+        pytest.fail("No pfw files found")
+
+    count = check_ai_events(path=paths[0])
+
+    if comm.rank == 0:
+        print("AI events count:", count)
+
+    # check single file from single rank only
+    assert count["root"]       == 1
+    assert count["epoch"]      == num_epochs
+    assert count["train"]      == num_epochs
+    assert count["eval"]       == 0
+    assert count["fetch_iter"] == num_epochs * (step // batch_size)
+    assert count["compute"]    == num_epochs * (step // batch_size)
+
+
+@pytest.mark.timeout(60, method="thread")
+@pytest.mark.parametrize("framework", ["pytorch", "tensorflow"])
+def test_ai_logging_with_eval(setup_test_env, framework):
+    storage_root = setup_test_env
+    num_epochs = 2
+    batch_size = 1
+    num_data_pp = 8
+    total_data = num_data_pp * comm.size
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.train=True",
+                "++workload.workflow.evaluation=True",
+                "++workload.workflow.generate_data=True",
+                f"++workload.output.folder={storage_root}",
+                f"++workload.dataset.data_folder={storage_root}/data",
+                f"++workload.dataset.num_files_train={total_data}",
+                f"++workload.dataset.num_files_eval={total_data}",
+                "++workload.dataset.num_subfolders_train=0",
+                "++workload.dataset.num_subfolders_eval=0",
+                f"++workload.reader.batch_size={batch_size}",
+                f"++workload.train.epochs={num_epochs}"
+            ],
+        )
+        run_benchmark(cfg)
+
+    paths = glob.glob(os.path.join(storage_root, "*.pfw"))
+    if len(paths) == 0:
+        pytest.fail("No pfw files found")
+
+    count = check_ai_events(path=paths[0])
+
+    if comm.rank == 0:
+        print("AI events count:", count)
+
+    # check single file from single rank only
+    assert count["root"]       == 1
+    assert count["epoch"]      == num_epochs
+    assert count["train"]      == num_epochs
+    assert count["eval"]       == num_epochs
+    assert count["fetch_iter"] == 2 * num_epochs * (num_data_pp // batch_size)
+    assert count["compute"]    == 2 * num_epochs * (num_data_pp // batch_size)


### PR DESCRIPTION
Hi @zhenghh04 and @hariharan-devarajan,

This PR adds dftracer AI/DL-based logging to DLIO using  for better consistent logging convention across all workloads.
There are no API changes so it stays backward compatible.

Since I am using end-to-end DFTracer + DLIO tests + dftracer events counting, I am able to capture a lot of hidden bugs in our codebase.

These are the summaries:

**AI logging integration:**
- Added `@dft_ai` annotations throughout DLIO pipeline 
- Integrated dftracer for compute, data loading, reader, and checkpointing

**Bug fixes:**
- Fixed event count mismatches between compute vs fetch operations
- Fixed training steps logging when `training_steps` is configured
- Fixed `statscounter` expecting scalar values (this got caught during my testing)
- Fixed checkpointing `load_state` issue where it does not expect `fsync` parameter at all but we pass it (this got caught as well)
- Fixed `tensorflow_io` incompatibility. Since we are not using it everywhere in code, I remove it (this makes CI failed, refer to 

**Testing:**
- Added comprehensive test suite with 73 test cases
- Covers PyTorch/TensorFlow frameworks
- Tests all data formats (HDF5, NPY, NPZ, TFRecord, CSV, JPEG, PNG, etc.)
- Includes checkpoint and evaluation workflows
- Updated CI to validate AI logging

**Other:**
- Bumped pydftracer version
- Added fallback when dftracer unavailable
- Cleaned up imports
