### PR TITLE
remove self.logger from reader factory

### DIFF
--- a/dlio_benchmark/reader/reader_factory.py
+++ b/dlio_benchmark/reader/reader_factory.py
@@ -35,8 +35,6 @@ class ReaderFactory(object):
 
         _args = ConfigArguments.get_instance()
         if _args.reader_class is not None:
-            if DLIOMPI.get_instance().rank() == 0:
-                self.logger.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
             return _args.reader_class(dataset_type, thread_index, epoch_number)
         elif type == FormatType.HDF5:
             if _args.odirect == True:


### PR DESCRIPTION
Since reader_factory's get_reader was changed to be a static method, the self.logger at line 39 needed to be removed as it throws error "self not defined" when using a custom data reader. 