### PR TITLE
feat: introduce Multi-Storage Client (MSC) as a storage provider

### DIFF
--- a/dlio_benchmark/checkpointing/checkpointing_factory.py
+++ b/dlio_benchmark/checkpointing/checkpointing_factory.py
@@ -42,5 +42,8 @@ class CheckpointingFactory(object):
         elif checkpoint_mechanism_type == CheckpointMechanismType.PT_S3_SAVE:
             from dlio_benchmark.checkpointing.pytorch_s3_checkpointing import PyTorchS3Checkpointing
             return PyTorchS3Checkpointing.get_instance()
+        elif checkpoint_mechanism_type == CheckpointMechanismType.PT_MSC_SAVE:
+            from dlio_benchmark.checkpointing.pytorch_msc_checkpointing import PyTorchMscCheckpointing
+            return PyTorchMscCheckpointing.get_instance()
         else:
             raise Exception(str(ErrorCodes.EC1005))

--- a/dlio_benchmark/checkpointing/pytorch_msc_checkpointing.py
+++ b/dlio_benchmark/checkpointing/pytorch_msc_checkpointing.py
@@ -1,0 +1,79 @@
+"""
+   Copyright (c) 2026, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import logging
+import os
+
+try:
+    import multistorageclient as msc
+    MSC_AVAILABLE = True
+except ImportError:
+    MSC_AVAILABLE = False
+    Path = None
+    logging.warning(
+        "Multi-Storage Client (MSC) not available. "
+        "Install with: pip install multi-storage-client"
+    )
+
+from dlio_benchmark.checkpointing.base_checkpointing import BaseCheckpointing
+from dlio_benchmark.checkpointing.pytorch_checkpointing import PyTorchCheckpointing
+from dlio_benchmark.common.constants import MODULE_CHECKPOINT
+from dlio_benchmark.utils.utility import Profile, dft_ai
+
+dlp = Profile(MODULE_CHECKPOINT)
+
+
+class PyTorchMscCheckpointing(PyTorchCheckpointing):
+    """
+    PyTorch checkpointing via NVIDIA Multi-Storage Client (MSC).
+    """
+    __instance = None
+
+    @staticmethod
+    def get_instance():
+        """ Static access method. """
+        if PyTorchMscCheckpointing.__instance is None:
+            PyTorchMscCheckpointing.__instance = PyTorchMscCheckpointing()
+        return PyTorchMscCheckpointing.__instance
+
+    @dft_ai.checkpoint.init
+    def __init__(self):
+        BaseCheckpointing.__init__(self, "ptmsc")
+        self.checkpoint_folder = self.args.storage_root
+
+    @dft_ai.checkpoint.capture
+    def save_state(self, suffix, state, fsync=False):
+        name = self.get_name(suffix)
+        msc.torch.save(state, os.path.join(self.checkpoint_folder, name))
+
+    @dft_ai.checkpoint.restart
+    def load_state(self, suffix, state):
+        name = self.get_name(suffix)
+        state = msc.torch.load(os.path.join(self.checkpoint_folder, name))
+        self.logger.debug(f"checkpoint state loaded: {state}")
+        assert len(state.keys()) > 0
+
+    @dlp.log
+    def save_checkpoint(self, epoch, step_number):
+        super().save_checkpoint(epoch, step_number)
+
+    @dlp.log
+    def load_checkpoint(self, epoch, step_number):
+        super().load_checkpoint(epoch, step_number)
+
+    @dlp.log
+    def finalize(self):
+        super().finalize()

--- a/dlio_benchmark/common/enumerations.py
+++ b/dlio_benchmark/common/enumerations.py
@@ -27,6 +27,7 @@ class CheckpointMechanismType(Enum):
     TF_SAVE = 'tf_save'
     PT_SAVE = 'pt_save'
     PT_S3_SAVE = 'pt_s3_save'
+    PT_MSC_SAVE = 'pt_msc_save'
 
     def __str__(self):
         return self.value
@@ -59,6 +60,7 @@ class StorageType(Enum):
     PARALLEL_FS = 'parallel_fs'
     S3 = 's3'
     AISTORE = 'aistore'
+    MSC = 'msc'
 
     def __str__(self):
         return self.value

--- a/dlio_benchmark/data_generator/generator_factory.py
+++ b/dlio_benchmark/data_generator/generator_factory.py
@@ -14,8 +14,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from dlio_benchmark.common.enumerations import FormatType
+from dlio_benchmark.common.enumerations import FormatType, StorageType
 from dlio_benchmark.common.error_code import ErrorCodes
+from dlio_benchmark.utils.config import ConfigArguments
+
 
 class GeneratorFactory(object):
     def __init__(self):
@@ -45,10 +47,20 @@ class GeneratorFactory(object):
             from dlio_benchmark.data_generator.png_generator import PNGGenerator
             return PNGGenerator()
         elif type == FormatType.SYNTHETIC:
-            from dlio_benchmark.data_generator.synthetic_generator import SyntheticGenerator
+            from dlio_benchmark.data_generator.synthetic_generator import (
+                SyntheticGenerator,
+            )
             return SyntheticGenerator()
         elif type == FormatType.INDEXED_BINARY or type == FormatType.MMAP_INDEXED_BINARY:
-            from dlio_benchmark.data_generator.indexed_binary_generator import IndexedBinaryGenerator
-            return IndexedBinaryGenerator()
+            if ConfigArguments.get_instance().storage_type == StorageType.MSC:
+                from dlio_benchmark.data_generator.indexed_binary_msc_generator import (
+                    IndexedBinaryMscGenerator,
+                )
+                return IndexedBinaryMscGenerator()
+            else:
+                from dlio_benchmark.data_generator.indexed_binary_generator import (
+                    IndexedBinaryGenerator,
+                )
+                return IndexedBinaryGenerator()
         else:
             raise Exception(str(ErrorCodes.EC1001))

--- a/dlio_benchmark/data_generator/indexed_binary_msc_generator.py
+++ b/dlio_benchmark/data_generator/indexed_binary_msc_generator.py
@@ -1,0 +1,123 @@
+"""
+   Copyright (c) 2026, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import os
+import struct
+import tempfile
+
+import numpy as np
+
+from dlio_benchmark.common.constants import MODULE_DATA_GENERATOR
+from dlio_benchmark.data_generator.data_generator import DataGenerator
+from dlio_benchmark.utils.utility import DLIOMPI, Profile, progress
+
+dlp = Profile(MODULE_DATA_GENERATOR)
+
+
+class IndexedBinaryMscGenerator(DataGenerator):
+    """
+    Generator for creating Indexed Binary data via the storage abstraction (MSC).
+
+    Unlike IndexedBinaryGenerator, this class does not use MPI collective I/O
+    (which requires a shared POSIX filesystem). Each rank independently writes
+    its assigned files through self.storage.upload_file().
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def index_file_path_off(self, prefix_path):
+        return prefix_path + '.off.idx'
+
+    def index_file_path_size(self, prefix_path):
+        return prefix_path + '.sz.idx'
+
+    @dlp.log
+    def generate(self):
+        super().generate()
+        np.random.seed(10)
+        dim = self.get_dimension(self.total_files_to_generate)
+
+        for i in dlp.iter(range(self.my_rank, int(self.total_files_to_generate), self.comm_size)):
+            dim_ = dim[2 * i]
+            shape_size = 0
+            if isinstance(dim_, list):
+                shape_size = np.prod(dim_)
+            else:
+                dim1 = dim_
+                dim2 = dim[2 * i + 1]
+                shape_size = dim1 * dim2
+
+            sample_size = shape_size * self._args.record_element_bytes
+            total_size = sample_size * self.num_samples
+            memory_size = self._args.generation_buffer_size
+            write_size = total_size
+            if total_size > memory_size:
+                write_size = memory_size - (memory_size % sample_size)
+
+            out_path_spec = self._file_list[i]
+            out_path_spec_off = self.index_file_path_off(out_path_spec)
+            out_path_spec_sz = self.index_file_path_size(out_path_spec)
+
+            progress(i + 1, self.total_files_to_generate, "Generating Indexed Binary Data (MSC)")
+
+            records = np.random.randint(255, size=write_size, dtype=np.uint8)
+
+            tmp_data = tempfile.NamedTemporaryFile(delete=False)
+            tmp_off = tempfile.NamedTemporaryFile(delete=False)
+            tmp_sz = tempfile.NamedTemporaryFile(delete=False)
+            try:
+                written_bytes = 0
+                while written_bytes < total_size:
+                    data_to_write = write_size if written_bytes + write_size <= total_size else total_size - written_bytes
+                    samples_to_write = data_to_write // sample_size
+
+                    # Write data
+                    myfmt = 'B' * data_to_write
+                    binary_data = struct.pack(myfmt, *records[:data_to_write])
+                    tmp_data.write(binary_data)
+                    struct._clearcache()
+
+                    # Write offsets
+                    myfmt = 'Q' * samples_to_write
+                    offsets = range(0, data_to_write, sample_size)
+                    offsets = offsets[:samples_to_write]
+                    binary_offsets = struct.pack(myfmt, *offsets)
+                    tmp_off.write(binary_offsets)
+
+                    # Write sizes
+                    myfmt = 'Q' * samples_to_write
+                    sample_sizes = [sample_size] * samples_to_write
+                    binary_sizes = struct.pack(myfmt, *sample_sizes)
+                    tmp_sz.write(binary_sizes)
+
+                    written_bytes = written_bytes + data_to_write
+
+                tmp_data.close()
+                tmp_off.close()
+                tmp_sz.close()
+
+                self.storage.upload_file(out_path_spec, tmp_data.name)
+                self.storage.upload_file(out_path_spec_off, tmp_off.name)
+                self.storage.upload_file(out_path_spec_sz, tmp_sz.name)
+            finally:
+                os.unlink(tmp_data.name)
+                os.unlink(tmp_off.name)
+                os.unlink(tmp_sz.name)
+
+        np.random.seed()
+        DLIOMPI.get_instance().comm().Barrier()

--- a/dlio_benchmark/reader/indexed_binary_msc_reader.py
+++ b/dlio_benchmark/reader/indexed_binary_msc_reader.py
@@ -1,0 +1,121 @@
+"""
+   Copyright (c) 2026, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import numpy as np
+
+from dlio_benchmark.common.constants import MODULE_DATA_READER
+from dlio_benchmark.common.enumerations import DataLoaderSampler
+from dlio_benchmark.reader.reader_handler import FormatReader
+from dlio_benchmark.storage.storage_factory import StorageFactory
+from dlio_benchmark.utils.utility import Profile, dft_ai
+
+dlp = Profile(MODULE_DATA_READER)
+
+
+class IndexedBinaryMscReader(FormatReader):
+    """
+    Reader for Indexed Binary files via MSC.
+    """
+
+    @dlp.log_init
+    def __init__(self, dataset_type, thread_index, epoch):
+        super().__init__(dataset_type, thread_index)
+        self.storage = StorageFactory().get_storage(
+            self._args.storage_type, self._args.storage_root, self._args.framework
+        )
+        self.file_map_ibr = {}
+        self.load_index()
+
+    def index_file_path_off(self, prefix_path):
+        prefix_path = prefix_path.replace(self.storage.storage_root, "")
+        return prefix_path + '.off.idx'
+
+    def index_file_path_size(self, prefix_path):
+        prefix_path = prefix_path.replace(self.storage.storage_root, "")
+        return prefix_path + '.sz.idx'
+
+    def binary_file_path(self, prefix_path):
+        prefix_path = prefix_path.replace(self.storage.storage_root, "")
+        return prefix_path
+
+    def _load_index_array(self, path, dtype=np.uint64):
+        """Fetch an entire index file and parse it as a numpy array."""
+        raw = self.storage.get_data(path, None)
+        return np.frombuffer(raw, dtype=dtype)
+
+    def load_index_file(self, global_sample_idx, filename, sample_index):
+        assert isinstance(filename, str), "filename must be a string"
+        if filename not in self.file_map_ibr:
+            offset_file = self.index_file_path_off(filename)
+            sz_file = self.index_file_path_size(filename)
+            self.file_map_ibr[filename] = [
+                self._load_index_array(offset_file),
+                self._load_index_array(sz_file),
+            ]
+            self.logger.debug(
+                f"loaded index for {filename}: "
+                f"{len(self.file_map_ibr[filename][0])} offsets, "
+                f"{len(self.file_map_ibr[filename][1])} sizes"
+            )
+
+    @dlp.log
+    def load_index(self):
+        if self._args.data_loader_sampler == DataLoaderSampler.ITERATIVE:
+            for global_sample_idx, filename, sample_index in self.file_map[self.thread_index]:
+                self.load_index_file(global_sample_idx, filename, sample_index)
+        elif self._args.data_loader_sampler == DataLoaderSampler.INDEX:
+            for global_sample_idx, (filename, sample_index) in self.global_index_map.items():
+                self.load_index_file(global_sample_idx, filename, sample_index)
+
+    @dlp.log
+    def open(self, filename):
+        super().open(filename)
+        return self.storage.open(self.binary_file_path(filename))
+
+    @dlp.log
+    def close(self, filename):
+        super().close(filename)
+        self.open_file_map[filename].close()
+
+    @dlp.log
+    def get_sample(self, filename, sample_index):
+        super().get_sample(filename, sample_index)
+        file = self.open_file_map[filename]
+        offset = self.file_map_ibr[filename][0][sample_index]
+        size = self.file_map_ibr[filename][1][sample_index]
+        self.logger.debug(f"reading sample from offset {offset} of size {size} from file {filename}")
+        file.seek(offset)
+        image = np.empty(size, dtype=np.uint8)
+        file.readinto(image)
+        dlp.update(image_size=size)
+
+    def next(self):
+        for batch in super().next():
+            yield batch
+
+    @dft_ai.data.item
+    def read_index(self, image_idx, step):
+        return super().read_index(image_idx, step)
+
+    @dlp.log
+    def finalize(self):
+        super().finalize()
+
+    def is_index_based(self):
+        return True
+
+    def is_iterator_based(self):
+        return True

--- a/dlio_benchmark/reader/reader_factory.py
+++ b/dlio_benchmark/reader/reader_factory.py
@@ -100,12 +100,18 @@ class ReaderFactory(object):
         elif type == FormatType.INDEXED_BINARY:
             if _args.odirect == True:
                 raise Exception("O_DIRECT for %s format is not yet supported." %type)
+            elif _args.storage_type == StorageType.MSC:
+                from dlio_benchmark.reader.indexed_binary_msc_reader import IndexedBinaryMscReader
+                return IndexedBinaryMscReader(dataset_type, thread_index, epoch_number)
             else:
                 from dlio_benchmark.reader.indexed_binary_reader import IndexedBinaryReader
                 return IndexedBinaryReader(dataset_type, thread_index, epoch_number)
         elif type == FormatType.MMAP_INDEXED_BINARY:
             if _args.odirect == True:
                 raise Exception("O_DIRECT for %s format is not yet supported." %type)
+            elif _args.storage_type == StorageType.MSC:
+                from dlio_benchmark.reader.indexed_binary_msc_reader import IndexedBinaryMscReader
+                return IndexedBinaryMscReader(dataset_type, thread_index, epoch_number)
             else:
                 from dlio_benchmark.reader.indexed_binary_mmap_reader import IndexedBinaryMMapReader
                 return IndexedBinaryMMapReader(dataset_type, thread_index, epoch_number)

--- a/dlio_benchmark/storage/msc_storage.py
+++ b/dlio_benchmark/storage/msc_storage.py
@@ -1,0 +1,159 @@
+"""
+   Copyright (c) 2025, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import logging
+import os
+import io
+
+try:
+    import multistorageclient as msc
+    MSC_AVAILABLE = True
+except ImportError:
+    MSC_AVAILABLE = False
+    Path = None
+    logging.warning(
+        "Multi-Storage Client (MSC) not available. "
+        "Install with: pip install multi-storage-client"
+    )
+
+from dlio_benchmark.common.constants import MODULE_STORAGE
+from dlio_benchmark.storage.storage_handler import DataStorage, Namespace
+from dlio_benchmark.common.enumerations import NamespaceType, MetadataType
+from dlio_benchmark.utils.utility import Profile
+
+dlp = Profile(MODULE_STORAGE)
+
+
+class MscStorage(DataStorage):
+    """
+    Storage backend using NVIDIA Multi-Storage Client (MSC).
+    """
+
+    @dlp.log_init
+    def __init__(self, namespace, framework=None):
+        super().__init__(None)
+        self.namespace = Namespace(namespace, NamespaceType.FLAT)
+        self.client, self.storage_root = msc.resolve_storage_client(self.namespace.name)
+    
+    @dlp.log
+    def get_uri(self, id):
+        """
+        Get the URI for an object.
+        """
+        return os.path.join(self.storage_root, id)
+
+    @dlp.log
+    def create_namespace(self, exist_ok=False):
+        """
+        Create the namespace for the storage. It's a noop for MSC.
+        """
+        return True
+
+    @dlp.log
+    def get_namespace(self):
+        return self.namespace.name
+
+    @dlp.log
+    def create_node(self, id, exist_ok=False):
+        return super().create_node(self.get_uri(id), exist_ok)
+
+    @dlp.log
+    def get_node(self, id):
+        assert isinstance(id, str), "id must be a string"
+        try:
+            info = self.client.info(self.get_uri(id))
+            if info.type == "file":
+                return MetadataType.FILE
+            elif info.type == "directory":
+                return MetadataType.DIRECTORY
+            else:
+                return None 
+        except Exception:
+            return None
+
+    @dlp.log
+    def walk_node(self, id, use_pattern=False):
+        assert isinstance(id, str), "id must be a string"
+        p = self.get_uri(id)
+        try:
+            objects = []
+            for entry in self.client.list(path=p):
+                name = entry.key
+                relative_name = name[len(p):]
+                if relative_name.startswith("/"):
+                    relative_name = relative_name[1:]
+                objects.append(relative_name)
+            return objects
+        except Exception as e:
+            logging.error(f"Error walking {id}: {e}")
+            return []
+
+    @dlp.log
+    def delete_node(self, id):
+        assert isinstance(id, str), "id must be a string"
+        try:
+            self.client.delete(self.get_uri(id), recursive=True)
+            return True
+        except Exception as e:
+            logging.error(f"Error deleting {id}: {e}")
+            return False
+
+    @dlp.log
+    def put_data(self, id, data, offset=None, length=None):
+        assert isinstance(id, str), "id must be a string"
+        try:
+            self.client.upload_file(self.get_uri(id), io.BytesIO(data))
+            return True
+        except Exception as e:
+            logging.error(f"Error writing data to {id}: {e}")
+            return False
+
+    @dlp.log
+    def get_data(self, id, data, offset=None, length=None):
+        assert isinstance(id, str), "id must be a string"
+        p = self.get_uri(id)
+        try:
+            if offset is not None and length is not None:
+                data = self.client.read_file(p, byte_range=msc.types.ByteRange(offset, length))
+            else:
+                data = self.client.read(p)
+            return data
+        except Exception as e:
+            logging.error(f"Error reading data from {id}: {e}")
+            return None
+
+    @dlp.log
+    def isfile(self, id):
+        assert isinstance(id, str), "id must be a string"
+        try:
+            info = self.client.info(self.get_uri(id))
+            return info.type == "file"
+        except Exception:
+            return False
+
+    def get_basename(self, id):
+        assert isinstance(id, str), "id must be a string"
+        return os.path.basename(self.get_uri(id))
+
+    def open(self, id):
+        assert isinstance(id, str), "id must be a string"
+        return self.client.open(self.get_uri(id))
+
+    def upload_file(self, id, filename):
+        assert isinstance(id, str), "id must be a string"
+        assert isinstance(filename, str), "filename must be a string"
+        self.client.upload_file(self.get_uri(id), filename)

--- a/dlio_benchmark/storage/storage_factory.py
+++ b/dlio_benchmark/storage/storage_factory.py
@@ -26,6 +26,13 @@ try:
 except ImportError:
     AISTORE_AVAILABLE = False
 
+# Guarded import for Multi-Storage Client
+try:
+    from dlio_benchmark.storage.msc_storage import MscStorage
+    MSC_AVAILABLE = True
+except ImportError:
+    MSC_AVAILABLE = False
+
 class StorageFactory(object):
     def __init__(self):
         pass
@@ -48,5 +55,12 @@ class StorageFactory(object):
                 from dlio_benchmark.storage.s3_torch_storage import S3PyTorchConnectorStorage
                 return S3PyTorchConnectorStorage(namespace, framework)
             return S3Storage(namespace, framework)
+        elif storage_type == StorageType.MSC:
+            if not MSC_AVAILABLE:
+                raise ImportError(
+                    "MSC storage type requires the multi-storage-client package. "
+                    "Install it with: pip install multi-storage-client"
+                )
+            return MscStorage(namespace, framework)
         else:
             raise Exception(str(ErrorCodes.EC1001))

--- a/dlio_benchmark/utils/config.py
+++ b/dlio_benchmark/utils/config.py
@@ -437,6 +437,15 @@ class ConfigArguments:
                     "Missing required S3 credentials for s3torchconnector: " + ", ".join(missing)
                 )
 
+        # MSC specific checks
+        if self.storage_type == StorageType.MSC:
+            try:
+                import multistorageclient
+            except ImportError:
+                raise Exception(
+                    "The multi-storage-client package is required for MSC storage but is not installed. "
+                    "Install it with: pip install multi-storage-client"
+                )
 
     @staticmethod
     def reset():
@@ -450,6 +459,8 @@ class ConfigArguments:
             elif self.framework == FrameworkType.PYTORCH:
                 if self.storage_type == StorageType.S3:
                     self.checkpoint_mechanism = CheckpointMechanismType.PT_S3_SAVE
+                elif self.storage_type == StorageType.MSC:
+                    self.checkpoint_mechanism = CheckpointMechanismType.PT_MSC_SAVE
                 else:
                     self.checkpoint_mechanism = CheckpointMechanismType.PT_SAVE
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,12 @@ core_deps = [
 x86_deps = [
     f"hydra-core>={HYDRA_VERSION}",
     "nvidia-dali-cuda120>=1.34.0",
-    "tensorflow>=2.13.1",
+    "torch>=2.2.0",
+    "torchaudio",
+    "torchvision",
+]
+darwin_arm64_deps = [
+    f"hydra-core>={HYDRA_VERSION}",
     "torch>=2.2.0",
     "torchaudio",
     "torchvision",
@@ -34,9 +39,12 @@ ppc_deps = [
 ]
 
 deps = core_deps
+platform = sysconfig.get_platform()
 
-if "ppc" in sysconfig.get_platform():
+if "ppc" in platform:
     deps.extend(ppc_deps)
+elif platform.startswith("macosx") and "arm64" in platform:
+    deps.extend(darwin_arm64_deps)
 else:
     deps.extend(x86_deps)
 
@@ -50,6 +58,9 @@ extras = {
     ],
     "aistore": [
         "aistore",
+    ],
+    "msc": [
+        "multi-storage-client[boto3]",
     ],
 }
 

--- a/tests/dlio_msc_benchmark_test.py
+++ b/tests/dlio_msc_benchmark_test.py
@@ -1,0 +1,362 @@
+"""
+   Copyright (c) 2026, UChicago Argonne, LLC
+   All Rights Reserved
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import glob
+import io
+import logging
+import os
+import uuid
+from datetime import datetime
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from hydra import compose, initialize_config_dir
+from mpi4py import MPI
+
+import dlio_benchmark
+from dlio_benchmark.main import DLIOBenchmark, set_dftracer_finalize, set_dftracer_initialize
+from dlio_benchmark.utils.config import ConfigArguments
+from dlio_benchmark.utils.utility import DLIOMPI
+from tests.utils import TEST_TIMEOUT_SECONDS
+
+pytest.importorskip("multistorageclient")
+
+comm = MPI.COMM_WORLD
+
+config_dir = os.path.dirname(dlio_benchmark.__file__) + "/configs/"
+
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.FileHandler("dlio_benchmark_test.log", mode="a", encoding="utf-8"),
+        logging.StreamHandler(),
+    ],
+    format="[%(levelname)s] %(message)s [%(pathname)s:%(lineno)d]",
+)
+
+
+def finalize():
+    pass
+
+
+def run_benchmark(cfg, verify=True):
+    comm.Barrier()
+    ConfigArguments.reset()
+    benchmark = DLIOBenchmark(cfg["workload"])
+    benchmark.initialize()
+    benchmark.run()
+    benchmark.finalize()
+    if comm.rank == 0 and verify:
+        assert len(glob.glob(benchmark.output_folder + "./*_output.json")) == benchmark.comm_size
+    return benchmark
+
+
+class MockMscClient:
+    """
+    Minimal MSC StorageClient stand-in: same call patterns as dlio_benchmark.storage.msc_storage.MscStorage.
+    Merges the object store across MPI ranks after mutating operations so walk_node/train work under mpirun.
+    """
+
+    def __init__(self, store: dict, mpi_comm):
+        self._store = store
+        self._comm = mpi_comm
+        self._primary_root: str | None = None
+
+    def _merge_from_all_ranks(self):
+        self._comm.Barrier()
+        chunks = self._comm.allgather(dict(self._store))
+        merged: dict = {}
+        for d in chunks:
+            merged.update(d)
+        self._store.clear()
+        self._store.update(merged)
+
+    def upload_file(self, dest_uri, src):
+        if isinstance(src, str):
+            with open(src, "rb") as f:
+                data = f.read()
+        else:
+            data = src.read()
+        self._store[dest_uri] = data
+        self._merge_from_all_ranks()
+
+    def read_file(self, uri, byte_range=None):
+        data = self._store.get(uri)
+        if data is None:
+            raise FileNotFoundError(uri)
+        if byte_range is None:
+            return data
+        off = getattr(byte_range, "offset", None)
+        ln = getattr(byte_range, "length", None)
+        if ln is None:
+            ln = getattr(byte_range, "size", None)
+        if off is None:
+            raise ValueError(f"Unsupported byte_range: {byte_range!r}")
+        return data[off : off + int(ln)]
+
+    def read(self, uri):
+        return self.read_file(uri, byte_range=None)
+
+    def open(self, uri):
+        raw = self.read(uri)
+        return BytesIO(raw)
+
+    def delete(self, uri, recursive=True):
+        if not recursive:
+            self._store.pop(uri, None)
+            self._merge_from_all_ranks()
+            return
+        prefix = uri.rstrip("/")
+        to_del = [k for k in list(self._store) if k == prefix or k.startswith(prefix + "/")]
+        for k in to_del:
+            del self._store[k]
+        self._merge_from_all_ranks()
+
+    def info(self, uri):
+        if uri in self._store:
+            return SimpleNamespace(type="file")
+        u = uri.rstrip("/")
+        for k in self._store:
+            if k.startswith(u + "/"):
+                return SimpleNamespace(type="directory")
+        raise FileNotFoundError(uri)
+
+    def list(self, path):
+        p = path.rstrip("/")
+        pref = p + "/"
+        seen = []
+        for k in sorted(self._store):
+            if not k.startswith(pref):
+                continue
+            rest = k[len(pref) :]
+            if "/" in rest:
+                continue
+            seen.append(SimpleNamespace(key=k))
+        return seen
+
+
+def _make_resolve_fn(client: MockMscClient):
+    def resolve_storage_client(namespace: str):
+        if namespace.startswith("msc://"):
+            root = namespace if namespace.endswith("/") else namespace + "/"
+            client._primary_root = root
+            return client, root
+        base = client._primary_root or "msc://dlio-msc-unset/"
+        base = base.rstrip("/")
+        root = f"{base}/{namespace.strip('/')}/"
+        return client, root
+
+    return resolve_storage_client
+
+
+def _msc_torch_bridge(store: dict, msc_client: MockMscClient):
+    def save(state, path):
+        buf = BytesIO()
+        torch.save(state, buf)
+        store[path] = buf.getvalue()
+        msc_client._merge_from_all_ranks()
+
+    def load(path, map_location=None):
+        buf = BytesIO(store[path])
+        return torch.load(buf, map_location=map_location, weights_only=False)
+
+    return SimpleNamespace(save=save, load=load)
+
+
+def _clean_msc_prefix(store: dict, prefix: str):
+    comm.Barrier()
+    p = prefix.rstrip("/")
+    for k in list(store.keys()):
+        if k.startswith(p):
+            del store[k]
+    comm.Barrier()
+
+
+@pytest.fixture
+def msc_test_env():
+    DLIOMPI.get_instance().initialize()
+    store: dict = {}
+    client = MockMscClient(store, comm)
+    resolve_fn = _make_resolve_fn(client)
+
+    if comm.rank == 0:
+        storage_root = f"msc://dlio-msc-{datetime.now().strftime('%Y%m%d%H%M%S')}-{uuid.uuid4()}/"
+    else:
+        storage_root = None
+    storage_root = comm.bcast(storage_root, root=0)
+
+    overrides = [
+        "++workload.storage.storage_type=msc",
+        f"++workload.storage.storage_root={storage_root}",
+        "++workload.dataset.data_folder=msc_dataset",
+        "++workload.dataset.num_subfolders_train=0",
+        "++workload.dataset.num_subfolders_eval=0",
+    ]
+
+    import dlio_benchmark.storage.msc_storage as msc_storage_mod
+    import dlio_benchmark.checkpointing.pytorch_msc_checkpointing as pt_msc_mod
+
+    mock_torch = _msc_torch_bridge(store, client)
+    with patch.object(msc_storage_mod.msc, "resolve_storage_client", side_effect=resolve_fn):
+        with patch.object(pt_msc_mod.msc, "torch", mock_torch, create=True):
+            comm.Barrier()
+            yield storage_root, store, overrides
+            comm.Barrier()
+
+
+@pytest.mark.timeout(TEST_TIMEOUT_SECONDS, method="thread")
+def test_msc_gen_data_indexed_binary(msc_test_env):
+    storage_root, store, msc_overrides = msc_test_env
+    if comm.rank == 0:
+        logging.info("MSC test: indexed_binary data generation")
+
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(
+            config_name="config",
+            overrides=msc_overrides
+            + [
+                "++workload.framework=pytorch",
+                "++workload.reader.data_loader=pytorch",
+                "++workload.workflow.train=False",
+                "++workload.workflow.generate_data=True",
+                "++workload.dataset.format=indexed_binary",
+                "++workload.dataset.num_files_train=2",
+                "++workload.dataset.num_files_eval=1",
+                "++workload.dataset.num_samples_per_file=4",
+                "++workload.dataset.record_length_bytes=256",
+            ],
+        )
+        run_benchmark(cfg, verify=False)
+
+    if comm.rank == 0:
+        train_prefix = os.path.join(storage_root.rstrip("/"), "msc_dataset", "train").replace("\\", "/")
+        for i in range(2):
+            base = f"{train_prefix}/img_{i}_of_2.indexed_binary"
+            assert base in store, f"missing {base}"
+            assert base + ".off.idx" in store
+            assert base + ".sz.idx" in store
+        valid_prefix = os.path.join(storage_root.rstrip("/"), "msc_dataset", "valid").replace("\\", "/")
+        v0 = f"{valid_prefix}/img_0_of_1.indexed_binary"
+        assert v0 in store
+        assert v0 + ".off.idx" in store
+        assert v0 + ".sz.idx" in store
+    finalize()
+    _clean_msc_prefix(store, storage_root)
+
+
+@pytest.mark.timeout(TEST_TIMEOUT_SECONDS, method="thread")
+def test_msc_train_indexed_binary_pytorch(msc_test_env):
+    storage_root, store, msc_overrides = msc_test_env
+    if comm.rank == 0:
+        logging.info("MSC test: indexed_binary train (pytorch dataloader)")
+
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        set_dftracer_finalize(False)
+        cfg = compose(
+            config_name="config",
+            overrides=msc_overrides
+            + [
+                "++workload.framework=pytorch",
+                "++workload.reader.data_loader=pytorch",
+                "++workload.workflow.train=True",
+                "++workload.workflow.generate_data=True",
+                "++workload.dataset.format=indexed_binary",
+                "++workload.dataset.num_files_train=2",
+                "++workload.dataset.num_files_eval=0",
+                "++workload.dataset.num_samples_per_file=8",
+                "++workload.dataset.record_length_bytes=512",
+                "++workload.reader.read_threads=1",
+                "++workload.reader.multiprocessing_context=fork",
+                "++workload.train.computation_time=0.01",
+                "++workload.train.epochs=1",
+            ],
+        )
+        run_benchmark(cfg, verify=True)
+    finalize()
+    _clean_msc_prefix(store, storage_root)
+
+
+@pytest.mark.timeout(TEST_TIMEOUT_SECONDS, method="thread")
+@pytest.mark.parametrize(
+    "framework, model_size, optimizers, num_layers, layer_params, zero_stage, randomize",
+    [("pytorch", 1024, [1024, 128], 2, [16], 0, True)],
+)
+def test_msc_checkpoint_pytorch(
+    msc_test_env,
+    framework,
+    model_size,
+    optimizers,
+    num_layers,
+    layer_params,
+    zero_stage,
+    randomize,
+):
+    storage_root, store, msc_overrides = msc_test_env
+    if comm.rank == 0:
+        logging.info("MSC test: PyTorch MSC checkpointing")
+
+    msc_overrides = list(msc_overrides) + ["++workload.checkpoint.checkpoint_folder=checkpoints"]
+
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        set_dftracer_initialize(False)
+        epochs = 4
+        epoch_per_ckp = 2
+        cfg = compose(
+            config_name="config",
+            overrides=msc_overrides
+            + [
+                f"++workload.framework={framework}",
+                f"++workload.reader.data_loader={framework}",
+                "++workload.workflow.train=True",
+                "++workload.workflow.generate_data=True",
+                "++workload.workflow.checkpoint=True",
+                f"++workload.checkpoint.randomize_tensor={randomize}",
+                "++workload.train.computation_time=0.01",
+                "++workload.evaluation.eval_time=0.005",
+                f"++workload.train.epochs={epochs}",
+                f"++workload.checkpoint.epochs_between_checkpoints={epoch_per_ckp}",
+                f"++workload.model.model_size={model_size}",
+                f"++workload.model.optimization_groups={optimizers}",
+                f"++workload.model.num_layers={num_layers}",
+                f"++workload.model.parallelism.zero_stage={zero_stage}",
+                f"++workload.model.layer_parameters={layer_params}",
+                f"++workload.model.parallelism.tensor={comm.size}",
+                "++workload.dataset.format=indexed_binary",
+                "++workload.dataset.num_files_train=4",
+                "++workload.dataset.num_files_eval=0",
+                "++workload.dataset.num_samples_per_file=4",
+                "++workload.dataset.record_length_bytes=256",
+                "++workload.reader.read_threads=1",
+                "++workload.reader.multiprocessing_context=fork",
+            ],
+        )
+        run_benchmark(cfg, verify=True)
+
+    if comm.rank == 0:
+        ptmsc_keys = [k for k in store if k.endswith(".ptmsc")]
+        nranks = comm.size
+        num_model_files = 1
+        num_optimizer_files = 1
+        num_layer_files = 1
+        files_per_checkpoint = (num_model_files + num_optimizer_files + num_layer_files) * nranks
+        num_check_files = epochs / epoch_per_ckp * files_per_checkpoint
+        assert len(ptmsc_keys) == num_check_files, f"got {len(ptmsc_keys)} {ptmsc_keys}"
+
+    finalize()
+    _clean_msc_prefix(store, storage_root)


### PR DESCRIPTION
## Summary

Adds [NVIDIA Multi-Storage Client (MSC)](https://pypi.org/project/multi-storage-client/) as an **optional** storage provider so DLIO can run data generation, training I/O, and PyTorch checkpointing against MSC-resolved backends (for example object storage such as S3, GCS, Azure, etc), consistent with existing `local_fs`, `parallel_fs`, `s3`, and `aistore` modes.

MSC is integrated for the **indexed binary** dataset format and **PyTorch** checkpointing.

## Configuration examples

### 1. MSC client configuration

MSC is configured in its own YAML file; see the [Configuration Reference](https://nvidia.github.io/multi-storage-client/references/configuration.html). A minimal **S3** profile looks like this:

```yaml
profiles:
  experiments:
    storage_provider:
      type: s3
      options:
        base_path: my-bucket
        region_name: us-east-1
```

Point MSC at your config file with the **`MSC_CONFIG`** environment variable (for example in the shell before running DLIO):

```bash
export MSC_CONFIG=/path/to/msc_config.yaml
```

### 2. DLIO workload profile (Hydra YAML)

In the workload, set `storage_type` to `msc` and set `storage_root` to an MSC URI. The segment immediately after `msc://` is the **profile name** (a key under `profiles:` in your MSC config, such as `experiments` in the S3 example above); the following path is the prefix for objects under that profile. DLIO passes `storage_root` to `multistorageclient.resolve_storage_client()`, so dataset and checkpoint paths combine with this prefix and are served through MSC.

```yaml
storage:
  storage_type: msc
  storage_root: msc://experiments/megatron-deepspeed/
```

For this snippet, `experiments` must be a profile defined in your MSC configuration file; `megatron-deepspeed/` is the artifact prefix under that profile.