### PR TITLE
fix: prevent barrier deadlock with uneven sample distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,14 +204,14 @@ jobs:
       - name: test_uneven_samples_deadlock
         run: |
           source ${VENV_PATH}/bin/activate
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-13-4]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-24-4]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-25-4]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-145-16]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-13-4]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-24-4]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-25-4]" -v
-          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-145-16]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-13-4]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-24-4]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-25-4]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-145-16]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-13-4]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-24-4]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-25-4]" -v
+          mpirun -np 3 --oversubscribe pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-145-16]" -v
           rm -rf data
       - name: test_custom_storage_root_train
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,18 @@ jobs:
           mpirun -np 2 pytest -k test_train[mmap_indexed_binary-tensorflow-dali-False] -v
           mpirun -np 2 pytest -k test_train[mmap_indexed_binary-pytorch-dali-False] -v
           rm -rf data
+      - name: test_uneven_samples_deadlock
+        run: |
+          source ${VENV_PATH}/bin/activate
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-13-4]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-24-4]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-25-4]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-pytorch-pytorch-145-16]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-13-4]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-24-4]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-25-4]" -v
+          mpirun -np 3 pytest -k "test_uneven_samples_deadlock[npz-tensorflow-tensorflow-145-16]" -v
+          rm -rf data
       - name: test_custom_storage_root_train
         run: |
           source ${VENV_PATH}/bin/activate

--- a/dlio_benchmark/main.py
+++ b/dlio_benchmark/main.py
@@ -220,6 +220,31 @@ class DLIOBenchmark(object):
                 self.logger.warning(
                     f"Number of files for evaluation in {os.path.join(self.args.data_folder, f'{DatasetType.VALID}')} ({len(file_list_eval)}) is more than requested ({self.num_files_eval}). A subset of files will be used ")
                 file_list_eval = file_list_eval[:self.num_files_eval]
+
+            """
+            _train and _eavl routines are expecting the same numbers of steps per epoch for each rank, enforced by barrier in the loop.
+            Providing number of train or eval that is not evenly divisible between ranks will lead to a deadlock as one of the ranks would do one less iteration.
+            This is especially noticeable in case of PyTorch Dataloader that drops last item in batch if it's less that batch size.
+            Adjusting number of sample files for even distribution across ranks here, at the source remove dependency on the individual data loader implementations.
+            """
+            samples_per_step_train = self.num_samples * self.batch_size * self.comm_size
+            aligned_samples_train = (self.num_files_train // samples_per_step_train) * samples_per_step_train
+            if self.num_files_train != aligned_samples_train:
+                if self.args.my_rank == 0:
+                    self.logger.warning(f"Trimming number of training files ({self.num_files_train} -> {aligned_samples_train}) to have equal number of train steps for all ranks")
+
+                self.num_files_train = aligned_samples_train
+                file_list_train = file_list_train[:self.num_files_train]
+
+            samples_per_step_eval = self.num_samples * self.batch_size_eval * self.comm_size
+            aligned_samples_eval = (self.num_files_eval // samples_per_step_eval) * samples_per_step_eval
+            if self.num_files_eval != aligned_samples_eval:
+                if self.args.my_rank == 0:
+                    self.logger.warning(f"Trimming number of evaluation files ({self.num_files_eval} -> {aligned_samples_eval}) to have equal number of eval steps for all ranks")
+
+                self.num_files_eval = aligned_samples_eval
+                file_list_eval = file_list_eval[:self.num_files_eval]
+
         self.args.derive_configurations(file_list_train, file_list_eval)
         self.args.validate()
         self.checkpointing_mechanism = None

--- a/tests/dlio_benchmark_test.py
+++ b/tests/dlio_benchmark_test.py
@@ -574,6 +574,44 @@ def test_train(fmt, framework, dataloader, is_even) -> None:
 
 
 @pytest.mark.timeout(TEST_TIMEOUT_SECONDS, method="thread")
+@pytest.mark.parametrize("fmt, framework, dataloader, num_files, batch_size", [
+    ("npz", "pytorch", "pytorch", 13, 4),
+    ("npz", "pytorch", "pytorch", 24, 4),
+    ("npz", "pytorch", "pytorch", 25, 4),
+    ("npz", "pytorch", "pytorch", 145, 16),
+    ("npz", "tensorflow", "tensorflow", 13, 4),
+    ("npz", "tensorflow", "tensorflow", 24, 4),
+    ("npz", "tensorflow", "tensorflow", 25, 4),
+    ("npz", "tensorflow", "tensorflow", 145, 16),
+])
+def test_uneven_samples_deadlock(fmt, framework, dataloader, num_files, batch_size) -> None:
+    init()
+    clean()
+    if comm.rank == 0:
+        logging.info("")
+        logging.info("=" * 80)
+        logging.info(f" DLIO test: uneven sample deadlock prevention ({fmt}, {num_files} files, bs={batch_size})")
+        logging.info("=" * 80)
+    with initialize_config_dir(version_base=None, config_dir=config_dir):
+        cfg = compose(config_name='config', overrides=[
+            '++workload.workflow.train=True',
+            '++workload.workflow.generate_data=True',
+            f'++workload.framework={framework}',
+            f'++workload.reader.data_loader={dataloader}',
+            f'++workload.dataset.format={fmt}',
+            f'++workload.reader.batch_size={batch_size}',
+            '++workload.train.computation_time=0.01',
+            '++workload.evaluation.eval_time=0.005',
+            '++workload.train.epochs=3',
+            f'++workload.dataset.num_files_train={num_files}',
+            '++workload.reader.read_threads=1',
+        ])
+        benchmark = run_benchmark(cfg)
+    clean()
+    finalize()
+
+
+@pytest.mark.timeout(TEST_TIMEOUT_SECONDS, method="thread")
 @pytest.mark.parametrize("fmt, framework", [("png", "tensorflow"), ("npz", "tensorflow"),
                                             ("jpeg", "tensorflow"), ("tfrecord", "tensorflow"),
                                             ("hdf5", "tensorflow"), ("csv", "tensorflow"),


### PR DESCRIPTION
When total samples aren't evenly divisible between ranks, number of training steps will be one off for one of the ranks, causing barrier deadlock, due to early exit from the loop.

For instance, if we have 3 ranks, 145 sample files with batch size 16:
- rank 0,1: 49 samples -> 3 steps per epoch,
- rank 2: 47 samples -> 2 steps per epoch (only two full batches)

Ranks 0 and 1 will be waiting for the barrier, while rank 2 will be starting new epoch.

Aligning number of sample files during the initialization solves the issue and makes it a bit more robust agains individual data loader implementations (e.g. PyTroch Dataloader drop_last = True).