### PR TITLE
fix: replace self.logger with _args.logger in static get_reader

### DIFF
--- a/dlio_benchmark/reader/reader_factory.py
+++ b/dlio_benchmark/reader/reader_factory.py
@@ -36,7 +36,7 @@ class ReaderFactory(object):
         _args = ConfigArguments.get_instance()
         if _args.reader_class is not None:
             if DLIOMPI.get_instance().rank() == 0:
-                self.logger.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
+                _args.logger.info(f"{utcnow()} Running DLIO with custom data loader class {_args.reader_class.__name__}")
             return _args.reader_class(dataset_type, thread_index, epoch_number)
         elif type == FormatType.HDF5:
             if _args.odirect == True:


### PR DESCRIPTION
Fixes #313.

`get_reader` is decorated with `@staticmethod` so `self` is not defined. Calling `self.logger.info()` raises `NameError` whenever a custom `reader_class` is configured.

**Fix:** replace `self.logger` with `_args.logger` (already in scope as `ConfigArguments.get_instance()`) rather than dropping the log line entirely, so the message is still emitted on rank 0.

The original PR #313 silently dropped the log line. This version preserves the log message with the correct logger.