### PR TITLE
fix(ci): install Sphinx via pip in docs deploy workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -28,10 +28,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Install Dependencies
         run: |
-          sudo apt-get install python3-sphinx
-          pip install sphinx_rtd_theme
+          python -m pip install --upgrade pip
+          pip install sphinx sphinx_rtd_theme
       - name: Build with Sphinx
         run: |
           cd ./docs


### PR DESCRIPTION
## Problem

The **Deploy Documentation** workflow (`.github/workflows/jekyll-gh-pages.yml`) is failing at the *Install Dependencies* step. See run [27424041112](https://github.com/argonne-lcf/dlio_benchmark/actions/runs/27424041112/job/81056916270):

```
sudo apt-get install python3-sphinx
Err:11 ... noble-updates/main amd64 python3-pil amd64 10.2.0-1ubuntu1
  404  Not Found [IP: 40.119.46.219 80]
E: Failed to fetch .../python3-pil_10.2.0-1ubuntu1_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
##[error]Process completed with exit code 100.
```

**Root cause:** `apt-get install python3-sphinx` runs without a preceding `apt-get update`. `python3-sphinx` recommends `python3-pil`, and the cached index points at version `10.2.0-1ubuntu1`, which has since been removed from the Ubuntu 24.04 (noble) mirror → 404 → exit 100. This is a recurring class of failure on hosted runners whenever the apt index drifts from the mirror.

## Fix

Drop the flaky apt path and install Sphinx from PyPI instead:

- Add `actions/setup-python@v5` so `pip install` targets an isolated interpreter (this also avoids the PEP 668 *externally-managed-environment* error that would otherwise hit the existing `pip install sphinx_rtd_theme` line on Ubuntu 24.04).
- Replace `sudo apt-get install python3-sphinx` + `pip install sphinx_rtd_theme` with `pip install sphinx sphinx_rtd_theme`.

Sphinx and `sphinx_rtd_theme` are pure-Python; the docs only use the built-in `sphinx.ext.autosectionlabel` extension, so no system packages are required. This is faster than apt and immune to mirror drift.

Also bumps `actions/configure-pages@v2` → `@v5` to clear the Node.js 20 deprecation warning flagged on the same run (v2 runs on the deprecated Node 20 runtime).

## Verification

Built the docs locally in a clean venv, mirroring the CI steps:

```
pip install sphinx sphinx_rtd_theme   # sphinx-build 9.0.4
cd docs && cp source/index.rst source/contents.rst && make html
# build succeeded, 29 warnings  (pre-existing content warnings; _build/html/index.html generated)
```

## Note (out of scope)

`actions/checkout@v4` still triggers the same Node.js 20 deprecation warning; it can be bumped to `@v5` in a follow-up if desired. This workflow also uploads the built site via `actions/upload-artifact` rather than `upload-pages-artifact` + `deploy-pages`, so it does not actually deploy to Pages — pre-existing and left untouched.